### PR TITLE
Add relationship filter to reduce overriding package parts

### DIFF
--- a/src/DocumentFormat.OpenXml.Framework/Features/IRelationshipFilterFeature.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/IRelationshipFilterFeature.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging.Builder;
+using System;
+
+namespace DocumentFormat.OpenXml.Features;
+
+internal interface IRelationshipFilterFeature
+{
+    void AddFilter(Action<PackageRelationshipBuilder> action);
+}

--- a/src/DocumentFormat.OpenXml.Framework/Features/PackageFeatureBase.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/PackageFeatureBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Packaging.Builder;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -10,10 +11,18 @@ using System.IO.Packaging;
 
 namespace DocumentFormat.OpenXml.Features;
 
-internal abstract class PackageFeatureBase : IPackage, IPackageFeature
+internal abstract class PackageFeatureBase : IPackage, IPackageFeature, IRelationshipFilterFeature
 {
+    private static readonly Uri _packageUri = new("/", UriKind.Relative);
+
+    private Action<PackageRelationshipBuilder>? _relationshipFilter;
     private RelationshipCache _relationships;
     private Dictionary<Uri, PackagePart>? _parts;
+
+    protected PackageFeatureBase()
+    {
+        _relationships = new(this);
+    }
 
     protected abstract Package Package { get; }
 
@@ -92,7 +101,7 @@ internal abstract class PackageFeatureBase : IPackage, IPackageFeature
     void IPackage.Save() => Package.Flush();
 
     public IPackageRelationship CreateRelationship(Uri targetUri, TargetMode targetMode, string? relationshipType, string? id)
-        => _relationships.GetOrCreate(Package.CreateRelationship(targetUri, targetMode, relationshipType, id));
+        => _relationships.GetOrCreate(_packageUri, Package.CreateRelationship(targetUri, targetMode, relationshipType, id));
 
     void IPackage.DeleteRelationship(string id)
     {
@@ -104,7 +113,7 @@ internal abstract class PackageFeatureBase : IPackage, IPackageFeature
     {
         foreach (var relationship in Package.GetRelationships())
         {
-            yield return _relationships.GetOrCreate(relationship);
+            yield return _relationships.GetOrCreate(_packageUri, relationship);
         }
     }
 
@@ -119,7 +128,7 @@ internal abstract class PackageFeatureBase : IPackage, IPackageFeature
     }
 
     public IPackageRelationship GetRelationship(string id)
-        => _relationships.GetOrCreate(Package.GetRelationship(id));
+        => _relationships.GetOrCreate(_packageUri, Package.GetRelationship(id));
 
     IPackage IPackageFeature.Package => this;
 
@@ -147,21 +156,25 @@ internal abstract class PackageFeatureBase : IPackage, IPackageFeature
     public virtual void Reload(FileMode? mode = null, FileAccess? access = null)
         => throw new NotSupportedException();
 
+    internal void RunFilter(PackageRelationshipBuilder builder) => _relationshipFilter?.Invoke(builder);
+
+    void IRelationshipFilterFeature.AddFilter(Action<PackageRelationshipBuilder> action)
+        => _relationshipFilter += action;
+
     private sealed class PackagePart : IPackagePart
     {
-        private readonly PackageFeatureBase _package;
-
         private RelationshipCache _relationships;
 
         public PackagePart(PackageFeatureBase package, System.IO.Packaging.PackagePart part)
         {
-            _package = package;
+            _relationships = new(package);
+
             Part = part;
         }
 
         public System.IO.Packaging.PackagePart Part { get; set; }
 
-        public IPackage Package => _package;
+        IPackage IPackagePart.Package => _relationships.Feature;
 
         public Uri Uri => Part.Uri;
 
@@ -177,7 +190,7 @@ internal abstract class PackageFeatureBase : IPackage, IPackageFeature
         {
             foreach (var relationship in Part.GetRelationships())
             {
-                yield return _relationships.GetOrCreate(relationship);
+                yield return _relationships.GetOrCreate(Part.Uri, relationship);
             }
         }
 
@@ -185,54 +198,37 @@ internal abstract class PackageFeatureBase : IPackage, IPackageFeature
             => Part.GetStream(open, write);
 
         public IPackageRelationship CreateRelationship(Uri targetUri, TargetMode targetMode, string relationshipType, string? id)
-            => _relationships.GetOrCreate(Part.CreateRelationship(targetUri, targetMode, relationshipType, id));
+            => _relationships.GetOrCreate(Part.Uri, Part.CreateRelationship(targetUri, targetMode, relationshipType, id));
 
         public bool RelationshipExists(string relationship)
             => Part.RelationshipExists(relationship);
 
         public IPackageRelationship GetRelationship(string id)
-            => _relationships.GetOrCreate(Part.GetRelationship(id));
-    }
-
-    private sealed class PackageRelationship : IPackageRelationship
-    {
-        public PackageRelationship(System.IO.Packaging.PackageRelationship relationship)
-        {
-            Id = relationship.Id;
-            RelationshipType = relationship.RelationshipType;
-            SourceUri = relationship.SourceUri;
-            TargetMode = relationship.TargetMode;
-            TargetUri = relationship.TargetUri;
-        }
-
-        public string Id { get; }
-
-        public string RelationshipType { get; }
-
-        public Uri SourceUri { get; }
-
-        public TargetMode TargetMode { get; }
-
-        public Uri TargetUri { get; }
+            => _relationships.GetOrCreate(Part.Uri, Part.GetRelationship(id));
     }
 
     private struct RelationshipCache
     {
-        private Dictionary<string, PackageRelationship>? _relationships;
+        private Dictionary<string, PackageRelationshipBuilder>? _relationships;
 
-        public IPackageRelationship GetOrCreate(System.IO.Packaging.PackageRelationship relationship)
+        public RelationshipCache(PackageFeatureBase feature)
+        {
+            Feature = feature;
+        }
+
+        public PackageFeatureBase Feature { get; }
+
+        public IPackageRelationship GetOrCreate(Uri partUri, PackageRelationship relationship)
         {
             if (_relationships is not null && _relationships.TryGetValue(relationship.Id, out var existing))
             {
                 return existing;
             }
 
-            if (_relationships is null)
-            {
-                _relationships = new Dictionary<string, PackageRelationship>();
-            }
+            _relationships ??= new Dictionary<string, PackageRelationshipBuilder>();
 
-            var newItem = new PackageRelationship(relationship);
+            var newItem = new PackageRelationshipBuilder(partUri, relationship);
+            Feature.RunFilter(newItem);
             _relationships[relationship.Id] = newItem;
             return newItem;
         }

--- a/src/DocumentFormat.OpenXml.Framework/Features/PackageStorageExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/PackageStorageExtensions.cs
@@ -12,37 +12,33 @@ internal static class PackageStorageExtensions
 {
     public static TPackage WithStorage<TPackage>(this TPackage package, Stream stream, PackageOpenMode mode)
         where TPackage : OpenXmlPackage
-    {
-        if (package.Features.Get<IPackageStreamFeature>() is { } streamFeature)
-        {
-            streamFeature.Stream = stream;
-        }
-        else
-        {
-            var streamPackage = new StreamPackageFeature(stream, mode);
-            package.Features.Set<IPackageFeature>(streamPackage);
-            package.Features.Set<IPackageStreamFeature>(streamPackage);
-            package.Features.GetRequired<IDisposableFeature>().Register(streamPackage);
-        }
-
-        return package;
-    }
+        => package.SetPackageFeatures(new StreamPackageFeature(stream, mode));
 
     public static TPackage WithStorage<TPackage>(this TPackage oPackage, Package package)
         where TPackage : OpenXmlPackage
-    {
-        oPackage.Features.Set<IPackageFeature>(new PackageFeature(package));
-        return oPackage;
-    }
+        => oPackage.SetPackageFeatures(new PackageFeature(package));
 
     public static TPackage WithStorage<TPackage>(this TPackage package, string path, PackageOpenMode mode)
         where TPackage : OpenXmlPackage
-    {
-        var streamPackage = new FilePackageFeature(path, mode);
+        => package.SetPackageFeatures(new FilePackageFeature(path, mode));
 
-        package.Features.Set<IPackageFeature>(streamPackage);
-        package.Features.Set<IPackageStreamFeature>(streamPackage);
-        package.Features.GetRequired<IDisposableFeature>().Register(streamPackage);
+    private static TPackage SetPackageFeatures<TPackage>(this TPackage package, PackageFeatureBase packageFeature)
+        where TPackage : OpenXmlPackage
+    {
+        var features = package.Features;
+
+        features.Set<IPackageFeature>(packageFeature);
+        features.Set<IRelationshipFilterFeature>(packageFeature);
+
+        if (packageFeature is IDisposable disposable)
+        {
+            features.GetRequired<IDisposableFeature>().Register(disposable);
+        }
+
+        if (packageFeature is IPackageStreamFeature streamFeature)
+        {
+            features.Set<IPackageStreamFeature>(streamFeature);
+        }
 
         return package;
     }

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/Builder/PackageRelationshipBuilder.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/Builder/PackageRelationshipBuilder.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO.Packaging;
+
+namespace DocumentFormat.OpenXml.Packaging.Builder;
+
+/// <summary>
+/// A mutable instance of a package relationship used while building the final relationship
+/// </summary>
+internal sealed class PackageRelationshipBuilder : IPackageRelationship
+{
+    internal PackageRelationshipBuilder(Uri partUri, PackageRelationship relationship)
+    {
+        Id = relationship.Id;
+        RelationshipType = relationship.RelationshipType;
+        SourceUri = relationship.SourceUri;
+        TargetMode = relationship.TargetMode;
+        TargetUri = relationship.TargetUri;
+        PartUri = partUri;
+    }
+
+    public Uri PartUri { get; }
+
+    /// <summary>
+    /// Gets or sets the id of the relationship.
+    /// </summary>
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the relationship type.
+    /// </summary>
+    public string RelationshipType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source URI.
+    /// </summary>
+    public Uri SourceUri { get; set; }
+
+    /// <summary>
+    /// Gets or sets the target mode.
+    /// </summary>
+    public TargetMode TargetMode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the target uri.
+    /// </summary>
+    public Uri TargetUri { get; set; }
+}

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/PackageUriHandlingExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/PackageUriHandlingExtensions.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using DocumentFormat.OpenXml.Features;
-using DocumentFormat.OpenXml.Framework;
 using DocumentFormat.OpenXml.Packaging.Builder;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Packaging;
 using System.Xml.Linq;
@@ -25,33 +23,28 @@ internal static class PackageUriHandlingExtensions
 
     internal static IFeatureCollection EnableUriHandling(this IFeatureCollection features)
     {
-        var feature = features.GetRequired<IPackageFeature>();
+        var packageFeature = features.GetRequired<IPackageFeature>();
 
-        if (feature.Capabilities.HasFlagFast(PackageCapabilities.MalformedUri))
+        if (packageFeature.Capabilities.HasFlagFast(PackageCapabilities.MalformedUri))
         {
             return features;
         }
 
-        if (feature.Package.FileOpenAccess == FileAccess.Read)
+        if (packageFeature.Package.FileOpenAccess == FileAccess.Read && !features.EnableWriteableStream())
         {
-            if (features.EnableWriteableStream())
-            {
-                // Don't register for disposal as we don't want it to write out to the temporary stream
-                features.Set<IPackageFeature>(new MalformedUriHandlingPackage(feature));
-            }
+            return features;
         }
-        else
-        {
-            var newFeature = new MalformedUriHandlingPackage(feature);
 
-            features.Set<IPackageFeature>(newFeature);
-            features.GetRequired<IDisposableFeature>().Register(newFeature);
-        }
+        var newFeature = new MalformedUriHandlingPackage(packageFeature);
+
+        features.GetRequired<IRelationshipFilterFeature>().AddFilter(newFeature.Filter);
+        features.Set<IPackageFeature>(newFeature);
+        features.GetRequired<IDisposableFeature>().Register(newFeature);
 
         return features;
     }
 
-    private static XDocument? WalkRelationships(IPackagePart part, KnownUris uris)
+    private static XDocument? WalkRelationships(IPackagePart part, RewrittenUriCollection uris)
     {
         using var stream = part.GetStream(FileMode.Open, FileAccess.Read);
         using var reader = new StreamReader(stream);
@@ -79,7 +72,7 @@ internal static class PackageUriHandlingExtensions
         return changed ? doc : null;
     }
 
-    private static bool Update(XElement child, KnownUris uris)
+    private static bool Update(XElement child, RewrittenUriCollection uris)
     {
         if (!EnumHelper.TryParse<TargetMode>(child.Attribute(TargetModeAttributeName)?.Value, out var targetMode))
         {
@@ -100,9 +93,9 @@ internal static class PackageUriHandlingExtensions
         }
 
         // if it already exists, we're writing things back out
-        if (uris.TryGetValue(id, out var existing) && string.Equals(existing.Replacement, target, StringComparison.OrdinalIgnoreCase))
+        if (uris.TryGetValue(id, out var existing) && string.Equals(existing.Target, target, StringComparison.OrdinalIgnoreCase))
         {
-            child.SetAttributeValue(TargetAttributeName, existing.Original);
+            child.SetAttributeValue(TargetAttributeName, existing.Target);
         }
         else if (target.Length > 0 && Uri.TryCreate(target, UriHelper.RelativeOrAbsolute, out _))
         {
@@ -122,7 +115,7 @@ internal static class PackageUriHandlingExtensions
 
     private sealed class MalformedUriHandlingPackage : DelegatingPackageFeature, IDisposable
     {
-        private readonly Dictionary<Uri, IPackagePart> _rewritten = new();
+        private readonly Dictionary<Uri, RewrittenUriCollection?> _rewritten = new();
 
         public override PackageCapabilities Capabilities => base.Capabilities | PackageCapabilities.MalformedUri;
 
@@ -132,36 +125,31 @@ internal static class PackageUriHandlingExtensions
         }
 
         public override IPackagePart GetPart(Uri uriTarget)
-            => WrapPartIfNeeded(uriTarget);
+             => WrapPartIfNeeded(base.GetPart(uriTarget));
 
-        private IPackagePart WrapPartIfNeeded(Uri uriTarget, IPackagePart? part = null)
+        private IPackagePart WrapPartIfNeeded(IPackagePart part)
         {
-            if (_rewritten.TryGetValue(uriTarget, out var existing))
-            {
-                return existing;
-            }
+            var uriTarget = part.Uri;
 
-            if (part is null)
+            if (_rewritten.ContainsKey(uriTarget))
             {
-                part = base.GetPart(uriTarget);
+                return part;
             }
 
             if (!PackUriHelper.IsRelationshipPartUri(uriTarget) && PackUriHelper.GetRelationshipPartUri(uriTarget) is { } relationshipUri && PartExists(relationshipUri))
             {
                 var relationshipPart = base.GetPart(relationshipUri);
-                var known = new KnownUris();
+                var known = new RewrittenUriCollection();
 
                 if (WalkRelationships(relationshipPart, known) is { } doc)
                 {
                     WriteStream(relationshipPart, doc);
-
-                    var handled = new MalformedUriPackagePart(this, part, known);
-                    _rewritten[uriTarget] = handled;
-                    return handled;
+                    _rewritten[uriTarget] = known;
+                    return part;
                 }
             }
 
-            _rewritten[uriTarget] = part;
+            _rewritten[uriTarget] = null;
             return part;
         }
 
@@ -196,7 +184,7 @@ internal static class PackageUriHandlingExtensions
         {
             foreach (var part in base.GetParts())
             {
-                yield return WrapPartIfNeeded(part.Uri, part);
+                yield return WrapPartIfNeeded(part);
             }
         }
 
@@ -209,12 +197,12 @@ internal static class PackageUriHandlingExtensions
 
             foreach (var malformed in _rewritten)
             {
-                if (malformed.Value is MalformedUriPackagePart part)
+                if (malformed.Value is { } uris)
                 {
                     var relationshipUri = PackUriHelper.GetRelationshipPartUri(malformed.Key);
                     var relationshipPart = base.GetPart(relationshipUri);
 
-                    if (WalkRelationships(relationshipPart, part.Known) is { } doc)
+                    if (WalkRelationships(relationshipPart, uris) is { } doc)
                     {
                         using var stream = relationshipPart.GetStream(FileMode.Create, FileAccess.Write);
                         stream.SetLength(0);
@@ -224,109 +212,37 @@ internal static class PackageUriHandlingExtensions
             }
         }
 
-        private sealed class MalformedUriPackagePart : DelegatingPackagePart
+        internal void Filter(PackageRelationshipBuilder relationship)
         {
-            public MalformedUriPackagePart(IPackage package, IPackagePart part, KnownUris known)
-                : base(package, part)
+            if (_rewritten.TryGetValue(relationship.PartUri, out var rewritten) && rewritten is not null && rewritten.TryGetValue(relationship.Id, out var known))
             {
-                Known = known;
-            }
-
-            public KnownUris Known { get; }
-
-            public override IPackageRelationship GetRelationship(string id)
-                => Normalize(base.GetRelationship(id));
-
-            private IPackageRelationship Normalize(IPackageRelationship relationship)
-            {
-                if (Known.TryGetValue(relationship.Id, out var replaced))
-                {
-                    return new MalformedRelationship(relationship, replaced.Original);
-                }
-
-                return relationship;
-            }
-
-            public override IEnumerable<IPackageRelationship> GetRelationships()
-            {
-                foreach (var relationship in base.GetRelationships())
-                {
-                    yield return Normalize(relationship);
-                }
-            }
-
-            private sealed class MalformedUri : Uri
-            {
-                private readonly string _original;
-
-                public MalformedUri(string uriString, string original)
-                    : base(uriString)
-                {
-                    _original = original;
-                }
-
-                public override string ToString() => _original;
-            }
-
-            private sealed class MalformedRelationship : IPackageRelationship
-            {
-                private readonly IPackageRelationship _other;
-
-                public MalformedRelationship(IPackageRelationship other, string actualUri)
-                {
-                    _other = other;
-                    TargetUri = new MalformedUri(other.TargetUri.ToString(), actualUri);
-                }
-
-                public string Id => _other.Id;
-
-                public string RelationshipType => _other.RelationshipType;
-
-                public Uri SourceUri => _other.SourceUri;
-
-                public TargetMode TargetMode => _other.TargetMode;
-
-                public Uri TargetUri { get; }
+                relationship.TargetUri = known;
             }
         }
     }
 
-    private class KnownUris : Dictionary<string, ReplacedUri>
+    private sealed class RewrittenUri : Uri
+    {
+        public RewrittenUri(string uriString, string original)
+            : base(uriString)
+        {
+            Target = original;
+        }
+
+        public string Target { get; }
+
+        public string Rewritten => OriginalString;
+
+        public override string ToString() => Target;
+    }
+
+    private class RewrittenUriCollection : Dictionary<string, RewrittenUri>
     {
         public string Register(string id, string target)
         {
-            var registered = new ReplacedUri(target);
-            Add(id, registered);
-            return registered.Replacement;
+            var replacement = new RewrittenUri($"rewritten://{Guid.NewGuid()}", target);
+            Add(id, replacement);
+            return replacement.Rewritten;
         }
-    }
-
-    private readonly struct ReplacedUri : IEquatable<ReplacedUri>
-    {
-        public ReplacedUri(string original)
-        {
-            Replacement = $"scheme://{Guid.NewGuid()}";
-            Original = original;
-        }
-
-        public string Original { get; }
-
-        public string Replacement { get; }
-
-        public override int GetHashCode()
-        {
-            var h = default(HashCode);
-
-            h.Add(Original, StringComparer.OrdinalIgnoreCase);
-            h.Add(Replacement, StringComparer.OrdinalIgnoreCase);
-
-            return h.ToHashCode();
-        }
-
-        public override bool Equals([NotNullWhen(true)] object? obj)
-            => obj is ReplacedUri key && Equals(key);
-
-        public bool Equals(ReplacedUri other)
-            => Original.Equals(other.Original) && string.Equals(Replacement, other.Replacement, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/PackageUriHandlingExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/PackageUriHandlingExtensions.cs
@@ -44,7 +44,7 @@ internal static class PackageUriHandlingExtensions
         return features;
     }
 
-    private static XDocument? WalkRelationships(IPackagePart part, RewrittenUriCollection uris)
+    private static XDocument? WalkRelationships(IPackagePart part, RewrittenUriCollection uris, bool isDisposing)
     {
         using var stream = part.GetStream(FileMode.Open, FileAccess.Read);
         using var reader = new StreamReader(stream);
@@ -62,7 +62,7 @@ internal static class PackageUriHandlingExtensions
         {
             foreach (var child in doc.Root.Descendants(XName.Get(RelationshipTagName, RelationshipNamespaceUri)))
             {
-                if (Update(child, uris))
+                if (Update(child, uris, isDisposing))
                 {
                     changed = true;
                 }
@@ -72,7 +72,7 @@ internal static class PackageUriHandlingExtensions
         return changed ? doc : null;
     }
 
-    private static bool Update(XElement child, RewrittenUriCollection uris)
+    private static bool Update(XElement child, RewrittenUriCollection uris, bool isDisposing)
     {
         if (!EnumHelper.TryParse<TargetMode>(child.Attribute(TargetModeAttributeName)?.Value, out var targetMode))
         {
@@ -92,10 +92,12 @@ internal static class PackageUriHandlingExtensions
             return false;
         }
 
-        // if it already exists, we're writing things back out
-        if (uris.TryGetValue(id, out var existing) && string.Equals(existing.Target, target, StringComparison.OrdinalIgnoreCase))
+        if (isDisposing)
         {
-            child.SetAttributeValue(TargetAttributeName, existing.Target);
+            if (uris.TryGetValue(id, out var existing) && string.Equals(existing.Rewritten, target, StringComparison.OrdinalIgnoreCase))
+            {
+                child.SetAttributeValue(TargetAttributeName, existing.Target);
+            }
         }
         else if (target.Length > 0 && Uri.TryCreate(target, UriHelper.RelativeOrAbsolute, out _))
         {
@@ -141,7 +143,7 @@ internal static class PackageUriHandlingExtensions
                 var relationshipPart = base.GetPart(relationshipUri);
                 var known = new RewrittenUriCollection();
 
-                if (WalkRelationships(relationshipPart, known) is { } doc)
+                if (WalkRelationships(relationshipPart, known, isDisposing: false) is { } doc)
                 {
                     WriteStream(relationshipPart, doc);
                     _rewritten[uriTarget] = known;
@@ -202,7 +204,7 @@ internal static class PackageUriHandlingExtensions
                     var relationshipUri = PackUriHelper.GetRelationshipPartUri(malformed.Key);
                     var relationshipPart = base.GetPart(relationshipUri);
 
-                    if (WalkRelationships(relationshipPart, uris) is { } doc)
+                    if (WalkRelationships(relationshipPart, uris, isDisposing: true) is { } doc)
                     {
                         using var stream = relationshipPart.GetStream(FileMode.Create, FileAccess.Write);
                         stream.SetLength(0);

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/PackageUriHandlingExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/PackageUriHandlingExtensions.cs
@@ -107,9 +107,7 @@ internal static class PackageUriHandlingExtensions
         {
             var updated = uris.Register(id, target);
 
-            Debug.Assert(Uri.TryCreate(updated, UriHelper.RelativeOrAbsolute, out _));
-
-            child.SetAttributeValue(TargetAttributeName, updated);
+            child.SetAttributeValue(TargetAttributeName, updated.Rewritten);
         }
 
         return true;
@@ -240,11 +238,11 @@ internal static class PackageUriHandlingExtensions
 
     private class RewrittenUriCollection : Dictionary<string, RewrittenUri>
     {
-        public string Register(string id, string target)
+        public RewrittenUri Register(string id, string target)
         {
             var replacement = new RewrittenUri($"rewritten://{Guid.NewGuid()}", target);
             Add(id, replacement);
-            return replacement.Rewritten;
+            return replacement;
         }
     }
 }

--- a/test/DocumentFormat.OpenXml.Framework.Tests/Features/PackageUriHandlingTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/Features/PackageUriHandlingTests.cs
@@ -28,7 +28,9 @@ public class PackageUriHandlingTests
         var disposable = Substitute.For<IDisposableFeature>();
         var feature = Substitute.For<IPackageFeature>();
         feature.Capabilities.Returns(capabilities);
+        var filter = Substitute.For<IRelationshipFilterFeature>();
 
+        features.Set(filter);
         features.Set(feature);
         features.Set(disposable);
 
@@ -59,6 +61,9 @@ public class PackageUriHandlingTests
         var disposable = Substitute.For<IDisposableFeature>();
         var feature = Substitute.For<IPackageFeature>();
         feature.Capabilities.Returns(PackageCapabilities.Save);
+        var filter = Substitute.For<IRelationshipFilterFeature>();
+
+        features.Set(filter);
 
         features.Set(disposable);
         features.Set(feature);
@@ -191,10 +196,10 @@ public class PackageUriHandlingTests
         CreateSimplePackage(stream);
         AddProblemRelationships(stream);
 
-        var packageFeature = new StreamPackageFeature(stream, isReadOnly ? PackageOpenMode.Read : PackageOpenMode.ReadWrite);
+        var package = Substitute.ForPartsOf<OpenXmlPackage>();
+        package.Features.Returns(features);
 
-        features.Set<IPackageFeature>(packageFeature);
-        features.Set<IPackageStreamFeature>(packageFeature);
+        package.WithStorage(stream, isReadOnly ? PackageOpenMode.Read : PackageOpenMode.ReadWrite);
 
         return features.EnableSavePackage();
     }


### PR DESCRIPTION
This allows for a callback to be registered that will filter out how relationships are defined without needing to override IPackagePart implementations.
