### PR TITLE
Use relationship filter for calcChain and recovered types

### DIFF
--- a/src/DocumentFormat.OpenXml.Framework/Features/PackageFeatureBase.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/PackageFeatureBase.cs
@@ -236,7 +236,11 @@ internal abstract class PackageFeatureBase : IPackage, IPackageFeature, IRelatio
                 {
                     var wrapped = new PackageRelationshipBuilder(Uri, relationship);
                     Feature.RunFilter(wrapped);
-                    _relationships.Add(wrapped.Id, wrapped);
+
+                    if (!wrapped.IsRemoved)
+                    {
+                        _relationships.Add(wrapped.Id, wrapped);
+                    }
                 }
             }
         }

--- a/src/DocumentFormat.OpenXml.Framework/Features/PackageStorageExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/PackageStorageExtensions.cs
@@ -52,6 +52,7 @@ internal static class PackageStorageExtensions
         var compatLevel = package.OpenSettings.CompatibilityLevel;
 
         package.UseTransitionalRelationshipNamespaces();
+        package.UseIgnoreRelationship("http://schemas.microsoft.com/office/2006/relationships/recovered");
 
         if (compatLevel >= CompatibilityLevel.Version_3_0)
         {

--- a/src/DocumentFormat.OpenXml.Framework/Features/PackageStorageExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/PackageStorageExtensions.cs
@@ -52,7 +52,7 @@ internal static class PackageStorageExtensions
         var compatLevel = package.OpenSettings.CompatibilityLevel;
 
         package.UseTransitionalRelationshipNamespaces();
-        package.UseIgnoreRelationship("http://schemas.microsoft.com/office/2006/relationships/recovered");
+        package.IgnoreRelationship("http://schemas.microsoft.com/office/2006/relationships/recovered");
 
         if (compatLevel >= CompatibilityLevel.Version_3_0)
         {

--- a/src/DocumentFormat.OpenXml.Framework/Features/RelationshipFilterExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/RelationshipFilterExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging;
+using System;
+using System.Collections.Generic;
+
+namespace DocumentFormat.OpenXml.Features;
+
+internal static class RelationshipFilterExtensions
+{
+    internal static void UseIgnoreRelationship(this OpenXmlPackage package, string relationshipType)
+    {
+        if (package.Features.Get<Relationships>() is not { } relationships)
+        {
+            relationships = new() { relationshipType };
+            var filter = package.Features.GetRequired<IRelationshipFilterFeature>();
+
+            filter.AddFilter(r =>
+            {
+                if (relationships.Contains(r.RelationshipType))
+                {
+                    r.IsRemoved = true;
+                }
+            });
+        }
+
+        relationships.Add(relationshipType);
+    }
+
+    private sealed class Relationships : HashSet<string>
+    {
+        public Relationships()
+            : base(StringComparer.OrdinalIgnoreCase)
+        {
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml.Framework/Features/RelationshipFilterExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/RelationshipFilterExtensions.cs
@@ -9,7 +9,7 @@ namespace DocumentFormat.OpenXml.Features;
 
 internal static class RelationshipFilterExtensions
 {
-    internal static void UseIgnoreRelationship(this OpenXmlPackage package, string relationshipType)
+    internal static void IgnoreRelationship(this OpenXmlPackage package, string relationshipType)
     {
         if (package.Features.Get<Relationships>() is not { } relationships)
         {

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/Builder/PackageRelationshipBuilder.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/Builder/PackageRelationshipBuilder.cs
@@ -47,4 +47,6 @@ internal sealed class PackageRelationshipBuilder : IPackageRelationship
     /// Gets or sets the target uri.
     /// </summary>
     public Uri TargetUri { get; set; }
+
+    internal bool IsRemoved { get; set; }
 }

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/OpenSettings.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/OpenSettings.cs
@@ -31,7 +31,6 @@ namespace DocumentFormat.OpenXml.Packaging
             MarkupCompatibilityProcessSettings.ProcessMode = other.MarkupCompatibilityProcessSettings.ProcessMode;
             MarkupCompatibilityProcessSettings.TargetFileFormatVersions = other.MarkupCompatibilityProcessSettings.TargetFileFormatVersions;
             MaxCharactersInPart = other.MaxCharactersInPart;
-            IgnoreExceptionOnCalcChainPartMissing = other.IgnoreExceptionOnCalcChainPartMissing;
             CompatibilityLevel = other.CompatibilityLevel;
         }
 
@@ -75,11 +74,5 @@ namespace DocumentFormat.OpenXml.Packaging
         /// This property allows you to mitigate denial of service attacks where the attacker submits a package with an extremely large Open XML part. By limiting the size of the part, you can detect the attack and recover reliably.
         /// </remarks>
         public long MaxCharactersInPart { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to ignore an exception if the calcChain part is missing.
-        /// The default value is false which means missing calcChain part will throw an exception upon package open.
-        /// </summary>
-        public bool IgnoreExceptionOnCalcChainPartMissing { get; set; }
     }
 }

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/PartRelationshipsFeature.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/PartRelationshipsFeature.cs
@@ -135,24 +135,10 @@ internal sealed class PartRelationshipsFeature :
         _referenceRelationships = new(StringComparer.Ordinal);
         _parts = new(StringComparer.Ordinal);
 
-        Dictionary<string, bool> partsToIgnore = new()
-        {
-            // Fix bug https://github.com/OfficeDev/Open-XML-SDK/issues/1281
-            { @"http://schemas.openxmlformats.org/officeDocument/2006/relationships/calcChain", openXmlPackage.OpenSettings.IgnoreExceptionOnCalcChainPartMissing },
-
-            // Fix bug https://github.com/OfficeDev/Open-XML-SDK/issues/1205
-            { @"http://schemas.microsoft.com/office/2006/relationships/recovered", true },
-        };
-
         var relationships = sourcePart?.PackagePart.Relationships ?? openXmlPackage.Package.Relationships;
 
         foreach (var relationship in relationships)
         {
-            if (partsToIgnore.TryGetValue(relationship.RelationshipType, out bool value) && value)
-            {
-                continue;
-            }
-
             if (relationship.RelationshipType == HyperlinkRelationship.RelationshipTypeConst)
             {
                 // Fix bug #517956 - both internal and external hyperlinks should be loaded as HyperlinkRelationship.

--- a/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using DocumentFormat.OpenXml.Features;
-using DocumentFormat.OpenXml.Packaging.Builder;
 using System;
 using System.IO;
 using System.IO.Packaging;

--- a/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocumentExtensions.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocumentExtensions.cs
@@ -13,6 +13,6 @@ public static class SpreadsheetDocumentExtensions
     /// <summary>
     /// Sets up the <paramref name="spreadsheet"/> to ignore any <see cref="CalculationChainPart"/> relationships if the part is not there.
     /// </summary>
-    public static void IgnoreCalcChainIfMissing(this SpreadsheetDocument spreadsheet)
-        => spreadsheet.UseIgnoreRelationship("http://schemas.openxmlformats.org/officeDocument/2006/relationships/calcChain");
+    public static void IgnoreCalculationChainPartRelationship(this SpreadsheetDocument spreadsheet)
+        => spreadsheet.IgnoreRelationship(CalculationChainPart.RelationshipTypeConstant);
 }

--- a/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocumentExtensions.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocumentExtensions.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Features;
+
+namespace DocumentFormat.OpenXml.Packaging;
+
+/// <summary>
+/// A collection of extensions for <see cref="SpreadsheetDocument"/>
+/// </summary>
+public static class SpreadsheetDocumentExtensions
+{
+    /// <summary>
+    /// Sets up the <paramref name="spreadsheet"/> to ignore any <see cref="CalculationChainPart"/> relationships if the part is not there.
+    /// </summary>
+    public static void IgnoreCalcChainIfMissing(this SpreadsheetDocument spreadsheet)
+        => spreadsheet.UseIgnoreRelationship("http://schemas.openxmlformats.org/officeDocument/2006/relationships/calcChain");
+}

--- a/test/DocumentFormat.OpenXml.Packaging.Tests/OpenXmlPackageTests.cs
+++ b/test/DocumentFormat.OpenXml.Packaging.Tests/OpenXmlPackageTests.cs
@@ -324,7 +324,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
 
             using SpreadsheetDocument spd = SpreadsheetDocument.Open(stmSpd, false);
 
-            spd.IgnoreCalcChainIfMissing();
+            spd.IgnoreCalculationChainPartRelationship();
 
             spd.LoadAllParts();
 

--- a/test/DocumentFormat.OpenXml.Packaging.Tests/OpenXmlPackageTests.cs
+++ b/test/DocumentFormat.OpenXml.Packaging.Tests/OpenXmlPackageTests.cs
@@ -311,7 +311,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
             using var stmSpd = GetStream(TestFiles.MissingCalcChainPart, false);
             using var doc = SpreadsheetDocument.Open(stmSpd, false);
 
-            Assert.Throws<InvalidOperationException>(() => doc.GetAllParts().ToList());
+            Assert.Throws<InvalidOperationException>(() => doc.LoadAllParts());
         }
 
         // When opening a workbook (SpreadsheetDocument.Open) with a missing calcChain part and OpenSettings
@@ -322,7 +322,12 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         {
             Stream stmSpd = GetStream(TestFiles.MissingCalcChainPart, false);
 
-            using SpreadsheetDocument spd = SpreadsheetDocument.Open(stmSpd, false, new OpenSettings() { IgnoreExceptionOnCalcChainPartMissing = true });
+            using SpreadsheetDocument spd = SpreadsheetDocument.Open(stmSpd, false);
+
+            spd.IgnoreCalcChainIfMissing();
+
+            spd.LoadAllParts();
+
             Assert.NotNull(spd);
         }
     }


### PR DESCRIPTION
This changes the relationship filtering to use the `IRelationshipFilterFeature` to register ignorable relationships. As part of this, the `OpenSettings.IgnoreExceptionOnCalcChainPartMissing` property has been removed and a new extension method has been added that can be opted into.

Fixes #1281