### PR TITLE
Use OrdinalIgnoreCase in LINQ generator

### DIFF
--- a/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Linq/LinqGeneratorExtensions.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Linq/LinqGeneratorExtensions.cs
@@ -57,7 +57,7 @@ public static class LinqGeneratorExtensions
         {
             var prefix = fieldInfoGrouping.Key;
             var namespaceName = fieldInfoGrouping.First().NamespaceName;
-            var classFieldInfos = fieldInfoGrouping.OrderBy(fi => fi.LocalName);
+            var classFieldInfos = fieldInfoGrouping.OrderBy(fi => fi.LocalName, StringComparer.OrdinalIgnoreCase);
 
             var className = GetClassName(prefix);
 

--- a/generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.NoNamespace.g.cs
+++ b/generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.NoNamespace.g.cs
@@ -300,18 +300,6 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName additive = "additive";
 
         /// <summary>
-        /// Represents the addlxml XML attribute.
-        /// </summary>
-        /// <remarks>
-        /// <para>As an XML attribute, it:</para>
-        /// <list type="bullet">
-        /// <item><description>is contained in the following XML elements: <see cref="O.signatureline" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.AdditionalXml.</description></item>
-        /// </list>
-        /// </remarks>
-        public static readonly XName addlxml = "addlxml";
-
-        /// <summary>
         /// Represents the addlXml XML attribute.
         /// </summary>
         /// <remarks>
@@ -322,6 +310,18 @@ namespace DocumentFormat.OpenXml.Linq
         /// </list>
         /// </remarks>
         public static readonly XName addlXml_ = "addlXml";
+
+        /// <summary>
+        /// Represents the addlxml XML attribute.
+        /// </summary>
+        /// <remarks>
+        /// <para>As an XML attribute, it:</para>
+        /// <list type="bullet">
+        /// <item><description>is contained in the following XML elements: <see cref="O.signatureline" />.</description></item>
+        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.AdditionalXml.</description></item>
+        /// </list>
+        /// </remarks>
+        public static readonly XName addlxml = "addlxml";
 
         /// <summary>
         /// Represents the address1 XML attribute.
@@ -648,18 +648,6 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName allowBlank = "allowBlank";
 
         /// <summary>
-        /// Represents the allowcomments XML attribute.
-        /// </summary>
-        /// <remarks>
-        /// <para>As an XML attribute, it:</para>
-        /// <list type="bullet">
-        /// <item><description>is contained in the following XML elements: <see cref="O.signatureline" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.AllowComments.</description></item>
-        /// </list>
-        /// </remarks>
-        public static readonly XName allowcomments = "allowcomments";
-
-        /// <summary>
         /// Represents the allowComments XML attribute.
         /// </summary>
         /// <remarks>
@@ -670,6 +658,18 @@ namespace DocumentFormat.OpenXml.Linq
         /// </list>
         /// </remarks>
         public static readonly XName allowComments_ = "allowComments";
+
+        /// <summary>
+        /// Represents the allowcomments XML attribute.
+        /// </summary>
+        /// <remarks>
+        /// <para>As an XML attribute, it:</para>
+        /// <list type="bullet">
+        /// <item><description>is contained in the following XML elements: <see cref="O.signatureline" />.</description></item>
+        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.AllowComments.</description></item>
+        /// </list>
+        /// </remarks>
+        public static readonly XName allowcomments = "allowcomments";
 
         /// <summary>
         /// Represents the allowedTaskSizes XML attributes.
@@ -3552,18 +3552,6 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName connection = "connection";
 
         /// <summary>
-        /// Represents the connectionId XML attributes.
-        /// </summary>
-        /// <remarks>
-        /// <para>As an XML attribute, it:</para>
-        /// <list type="bullet">
-        /// <item><description>is contained in the following XML elements: <see cref="X.cacheSource" />, <see cref="X.queryTable" />, <see cref="X.singleXmlCell" />, <see cref="X.table" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed properties: CacheSource.ConnectionId, QueryTable.ConnectionId, SingleXmlCell.ConnectionId, Table.ConnectionId.</description></item>
-        /// </list>
-        /// </remarks>
-        public static readonly XName connectionId = "connectionId";
-
-        /// <summary>
         /// Represents the ConnectionID XML attribute.
         /// </summary>
         /// <remarks>
@@ -3574,6 +3562,18 @@ namespace DocumentFormat.OpenXml.Linq
         /// </list>
         /// </remarks>
         public static readonly XName ConnectionID_ = "ConnectionID";
+
+        /// <summary>
+        /// Represents the connectionId XML attributes.
+        /// </summary>
+        /// <remarks>
+        /// <para>As an XML attribute, it:</para>
+        /// <list type="bullet">
+        /// <item><description>is contained in the following XML elements: <see cref="X.cacheSource" />, <see cref="X.queryTable" />, <see cref="X.singleXmlCell" />, <see cref="X.table" />.</description></item>
+        /// <item><description>corresponds to the following strongly-typed properties: CacheSource.ConnectionId, QueryTable.ConnectionId, SingleXmlCell.ConnectionId, Table.ConnectionId.</description></item>
+        /// </list>
+        /// </remarks>
+        public static readonly XName connectionId = "connectionId";
 
         /// <summary>
         /// Represents the connectloc XML attribute.
@@ -6048,18 +6048,6 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName dropStyle = "dropStyle";
 
         /// <summary>
-        /// Represents the dt XML attributes.
-        /// </summary>
-        /// <remarks>
-        /// <para>As an XML attribute, it:</para>
-        /// <list type="bullet">
-        /// <item><description>is contained in the following XML elements: <see cref="P.cm" />, <see cref="P.hf" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed properties: Comment.DateTime, HeaderFooter.DateTime.</description></item>
-        /// </list>
-        /// </remarks>
-        public static readonly XName dt = "dt";
-
-        /// <summary>
         /// Represents the dT XML attribute.
         /// </summary>
         /// <remarks>
@@ -6070,6 +6058,18 @@ namespace DocumentFormat.OpenXml.Linq
         /// </list>
         /// </remarks>
         public static readonly XName dT_ = "dT";
+
+        /// <summary>
+        /// Represents the dt XML attributes.
+        /// </summary>
+        /// <remarks>
+        /// <para>As an XML attribute, it:</para>
+        /// <list type="bullet">
+        /// <item><description>is contained in the following XML elements: <see cref="P.cm" />, <see cref="P.hf" />.</description></item>
+        /// <item><description>corresponds to the following strongly-typed properties: Comment.DateTime, HeaderFooter.DateTime.</description></item>
+        /// </list>
+        /// </remarks>
+        public static readonly XName dt = "dt";
 
         /// <summary>
         /// Represents the dt2D XML attribute.
@@ -6168,18 +6168,6 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName dxf = "dxf";
 
         /// <summary>
-        /// Represents the dxfid XML attribute.
-        /// </summary>
-        /// <remarks>
-        /// <para>As an XML attribute, it:</para>
-        /// <list type="bullet">
-        /// <item><description>is contained in the following XML elements: <see cref="XLRD2.rSty" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed properties: RichStyle.Dxfid.</description></item>
-        /// </list>
-        /// </remarks>
-        public static readonly XName dxfid = "dxfid";
-
-        /// <summary>
         /// Represents the dxfId XML attributes.
         /// </summary>
         /// <remarks>
@@ -6190,6 +6178,18 @@ namespace DocumentFormat.OpenXml.Linq
         /// </list>
         /// </remarks>
         public static readonly XName dxfId_ = "dxfId";
+
+        /// <summary>
+        /// Represents the dxfid XML attribute.
+        /// </summary>
+        /// <remarks>
+        /// <para>As an XML attribute, it:</para>
+        /// <list type="bullet">
+        /// <item><description>is contained in the following XML elements: <see cref="XLRD2.rSty" />.</description></item>
+        /// <item><description>corresponds to the following strongly-typed properties: RichStyle.Dxfid.</description></item>
+        /// </list>
+        /// </remarks>
+        public static readonly XName dxfid = "dxfid";
 
         /// <summary>
         /// Represents the dynamicSet XML attribute.
@@ -6264,18 +6264,6 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName edit = "edit";
 
         /// <summary>
-        /// Represents the editas XML attribute.
-        /// </summary>
-        /// <remarks>
-        /// <para>As an XML attribute, it:</para>
-        /// <list type="bullet">
-        /// <item><description>is contained in the following XML elements: <see cref="V.group" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed properties: Group.EditAs.</description></item>
-        /// </list>
-        /// </remarks>
-        public static readonly XName editas = "editas";
-
-        /// <summary>
         /// Represents the editAs XML attribute.
         /// </summary>
         /// <remarks>
@@ -6286,6 +6274,18 @@ namespace DocumentFormat.OpenXml.Linq
         /// </list>
         /// </remarks>
         public static readonly XName editAs_ = "editAs";
+
+        /// <summary>
+        /// Represents the editas XML attribute.
+        /// </summary>
+        /// <remarks>
+        /// <para>As an XML attribute, it:</para>
+        /// <list type="bullet">
+        /// <item><description>is contained in the following XML elements: <see cref="V.group" />.</description></item>
+        /// <item><description>corresponds to the following strongly-typed properties: Group.EditAs.</description></item>
+        /// </list>
+        /// </remarks>
+        public static readonly XName editas = "editas";
 
         /// <summary>
         /// Represents the editData XML attribute.
@@ -10344,18 +10344,6 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName invertible = "invertible";
 
         /// <summary>
-        /// Represents the invx XML attribute.
-        /// </summary>
-        /// <remarks>
-        /// <para>As an XML attribute, it:</para>
-        /// <list type="bullet">
-        /// <item><description>is contained in the following XML elements: <see cref="V.h" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed properties: ShapeHandle.InvertX.</description></item>
-        /// </list>
-        /// </remarks>
-        public static readonly XName invx = "invx";
-
-        /// <summary>
         /// Represents the invX XML attribute.
         /// </summary>
         /// <remarks>
@@ -10368,16 +10356,16 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName invX_ = "invX";
 
         /// <summary>
-        /// Represents the invy XML attribute.
+        /// Represents the invx XML attribute.
         /// </summary>
         /// <remarks>
         /// <para>As an XML attribute, it:</para>
         /// <list type="bullet">
         /// <item><description>is contained in the following XML elements: <see cref="V.h" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed properties: ShapeHandle.InvertY.</description></item>
+        /// <item><description>corresponds to the following strongly-typed properties: ShapeHandle.InvertX.</description></item>
         /// </list>
         /// </remarks>
-        public static readonly XName invy = "invy";
+        public static readonly XName invx = "invx";
 
         /// <summary>
         /// Represents the invY XML attribute.
@@ -10390,6 +10378,18 @@ namespace DocumentFormat.OpenXml.Linq
         /// </list>
         /// </remarks>
         public static readonly XName invY_ = "invY";
+
+        /// <summary>
+        /// Represents the invy XML attribute.
+        /// </summary>
+        /// <remarks>
+        /// <para>As an XML attribute, it:</para>
+        /// <list type="bullet">
+        /// <item><description>is contained in the following XML elements: <see cref="V.h" />.</description></item>
+        /// <item><description>corresponds to the following strongly-typed properties: ShapeHandle.InvertY.</description></item>
+        /// </list>
+        /// </remarks>
+        public static readonly XName invy = "invy";
 
         /// <summary>
         /// Represents the isActiveX XML attribute.
@@ -10512,18 +10512,6 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName isPhoto = "isPhoto";
 
         /// <summary>
-        /// Represents the issignatureline XML attribute.
-        /// </summary>
-        /// <remarks>
-        /// <para>As an XML attribute, it:</para>
-        /// <list type="bullet">
-        /// <item><description>is contained in the following XML elements: <see cref="O.signatureline" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.IsSignatureLine.</description></item>
-        /// </list>
-        /// </remarks>
-        public static readonly XName issignatureline = "issignatureline";
-
-        /// <summary>
         /// Represents the isSignatureLine XML attribute.
         /// </summary>
         /// <remarks>
@@ -10534,6 +10522,18 @@ namespace DocumentFormat.OpenXml.Linq
         /// </list>
         /// </remarks>
         public static readonly XName isSignatureLine_ = "isSignatureLine";
+
+        /// <summary>
+        /// Represents the issignatureline XML attribute.
+        /// </summary>
+        /// <remarks>
+        /// <para>As an XML attribute, it:</para>
+        /// <list type="bullet">
+        /// <item><description>is contained in the following XML elements: <see cref="O.signatureline" />.</description></item>
+        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.IsSignatureLine.</description></item>
+        /// </list>
+        /// </remarks>
+        public static readonly XName issignatureline = "issignatureline";
 
         /// <summary>
         /// Represents the item XML attributes.
@@ -15480,18 +15480,6 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName @protected = "protected";
 
         /// <summary>
-        /// Represents the provid XML attribute.
-        /// </summary>
-        /// <remarks>
-        /// <para>As an XML attribute, it:</para>
-        /// <list type="bullet">
-        /// <item><description>is contained in the following XML elements: <see cref="O.signatureline" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.ProviderId.</description></item>
-        /// </list>
-        /// </remarks>
-        public static readonly XName provid = "provid";
-
-        /// <summary>
         /// Represents the provId XML attribute.
         /// </summary>
         /// <remarks>
@@ -15502,6 +15490,18 @@ namespace DocumentFormat.OpenXml.Linq
         /// </list>
         /// </remarks>
         public static readonly XName provId_ = "provId";
+
+        /// <summary>
+        /// Represents the provid XML attribute.
+        /// </summary>
+        /// <remarks>
+        /// <para>As an XML attribute, it:</para>
+        /// <list type="bullet">
+        /// <item><description>is contained in the following XML elements: <see cref="O.signatureline" />.</description></item>
+        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.ProviderId.</description></item>
+        /// </list>
+        /// </remarks>
+        public static readonly XName provid = "provid";
 
         /// <summary>
         /// Represents the provider XML attribute.
@@ -16740,18 +16740,6 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName rotation = "rotation";
 
         /// <summary>
-        /// Represents the rotationangle XML attribute.
-        /// </summary>
-        /// <remarks>
-        /// <para>As an XML attribute, it:</para>
-        /// <list type="bullet">
-        /// <item><description>is contained in the following XML elements: <see cref="O.extrusion" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed properties: Extrusion.RotationAngle.</description></item>
-        /// </list>
-        /// </remarks>
-        public static readonly XName rotationangle = "rotationangle";
-
-        /// <summary>
         /// Represents the rotationAngle XML attribute.
         /// </summary>
         /// <remarks>
@@ -16762,6 +16750,18 @@ namespace DocumentFormat.OpenXml.Linq
         /// </list>
         /// </remarks>
         public static readonly XName rotationAngle_ = "rotationAngle";
+
+        /// <summary>
+        /// Represents the rotationangle XML attribute.
+        /// </summary>
+        /// <remarks>
+        /// <para>As an XML attribute, it:</para>
+        /// <list type="bullet">
+        /// <item><description>is contained in the following XML elements: <see cref="O.extrusion" />.</description></item>
+        /// <item><description>corresponds to the following strongly-typed properties: Extrusion.RotationAngle.</description></item>
+        /// </list>
+        /// </remarks>
+        public static readonly XName rotationangle = "rotationangle";
 
         /// <summary>
         /// Represents the rotationcenter XML attribute.
@@ -18648,18 +18648,6 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName showSheetTabs = "showSheetTabs";
 
         /// <summary>
-        /// Represents the showsigndate XML attribute.
-        /// </summary>
-        /// <remarks>
-        /// <para>As an XML attribute, it:</para>
-        /// <list type="bullet">
-        /// <item><description>is contained in the following XML elements: <see cref="O.signatureline" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.ShowSignDate.</description></item>
-        /// </list>
-        /// </remarks>
-        public static readonly XName showsigndate = "showsigndate";
-
-        /// <summary>
         /// Represents the showSignDate XML attribute.
         /// </summary>
         /// <remarks>
@@ -18670,6 +18658,18 @@ namespace DocumentFormat.OpenXml.Linq
         /// </list>
         /// </remarks>
         public static readonly XName showSignDate_ = "showSignDate";
+
+        /// <summary>
+        /// Represents the showsigndate XML attribute.
+        /// </summary>
+        /// <remarks>
+        /// <para>As an XML attribute, it:</para>
+        /// <list type="bullet">
+        /// <item><description>is contained in the following XML elements: <see cref="O.signatureline" />.</description></item>
+        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.ShowSignDate.</description></item>
+        /// </list>
+        /// </remarks>
+        public static readonly XName showsigndate = "showsigndate";
 
         /// <summary>
         /// Represents the showSpeakerNotes XML attribute.
@@ -18864,18 +18864,6 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName side = "side";
 
         /// <summary>
-        /// Represents the signinginstructions XML attribute.
-        /// </summary>
-        /// <remarks>
-        /// <para>As an XML attribute, it:</para>
-        /// <list type="bullet">
-        /// <item><description>is contained in the following XML elements: <see cref="O.signatureline" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.SigningInstructions.</description></item>
-        /// </list>
-        /// </remarks>
-        public static readonly XName signinginstructions = "signinginstructions";
-
-        /// <summary>
         /// Represents the signingInstructions XML attribute.
         /// </summary>
         /// <remarks>
@@ -18888,16 +18876,16 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName signingInstructions_ = "signingInstructions";
 
         /// <summary>
-        /// Represents the signinginstructionsset XML attribute.
+        /// Represents the signinginstructions XML attribute.
         /// </summary>
         /// <remarks>
         /// <para>As an XML attribute, it:</para>
         /// <list type="bullet">
         /// <item><description>is contained in the following XML elements: <see cref="O.signatureline" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.SigningInstructionsSet.</description></item>
+        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.SigningInstructions.</description></item>
         /// </list>
         /// </remarks>
-        public static readonly XName signinginstructionsset = "signinginstructionsset";
+        public static readonly XName signinginstructions = "signinginstructions";
 
         /// <summary>
         /// Represents the signingInstructionsSet XML attribute.
@@ -18912,16 +18900,16 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName signingInstructionsSet_ = "signingInstructionsSet";
 
         /// <summary>
-        /// Represents the sigprovurl XML attribute.
+        /// Represents the signinginstructionsset XML attribute.
         /// </summary>
         /// <remarks>
         /// <para>As an XML attribute, it:</para>
         /// <list type="bullet">
         /// <item><description>is contained in the following XML elements: <see cref="O.signatureline" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.SignatureProviderUrl.</description></item>
+        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.SigningInstructionsSet.</description></item>
         /// </list>
         /// </remarks>
-        public static readonly XName sigprovurl = "sigprovurl";
+        public static readonly XName signinginstructionsset = "signinginstructionsset";
 
         /// <summary>
         /// Represents the sigProvUrl XML attribute.
@@ -18934,6 +18922,18 @@ namespace DocumentFormat.OpenXml.Linq
         /// </list>
         /// </remarks>
         public static readonly XName sigProvUrl_ = "sigProvUrl";
+
+        /// <summary>
+        /// Represents the sigprovurl XML attribute.
+        /// </summary>
+        /// <remarks>
+        /// <para>As an XML attribute, it:</para>
+        /// <list type="bullet">
+        /// <item><description>is contained in the following XML elements: <see cref="O.signatureline" />.</description></item>
+        /// <item><description>corresponds to the following strongly-typed properties: SignatureLine.SignatureProviderUrl.</description></item>
+        /// </list>
+        /// </remarks>
+        public static readonly XName sigprovurl = "sigprovurl";
 
         /// <summary>
         /// Represents the simplePos XML attribute.

--- a/generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.X.g.cs
+++ b/generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.X.g.cs
@@ -2350,19 +2350,6 @@ namespace DocumentFormat.OpenXml.Linq
         public static readonly XName main = x + "main";
 
         /// <summary>
-        /// Represents the x:map XML element.
-        /// </summary>
-        /// <remarks>
-        /// <para>As an XML element, it:</para>
-        /// <list type="bullet">
-        /// <item><description>has the following parent XML elements: <see cref="maps" />.</description></item>
-        /// <item><description>has the following XML attributes: <see cref="NoNamespace.dimension" />, <see cref="NoNamespace.measureGroup" />.</description></item>
-        /// <item><description>corresponds to the following strongly-typed classes: MeasureDimensionMap.</description></item>
-        /// </list>
-        /// </remarks>
-        public static readonly XName map = x + "map";
-
-        /// <summary>
         /// Represents the x:Map XML element.
         /// </summary>
         /// <remarks>
@@ -2375,6 +2362,19 @@ namespace DocumentFormat.OpenXml.Linq
         /// </list>
         /// </remarks>
         public static readonly XName Map_ = x + "Map";
+
+        /// <summary>
+        /// Represents the x:map XML element.
+        /// </summary>
+        /// <remarks>
+        /// <para>As an XML element, it:</para>
+        /// <list type="bullet">
+        /// <item><description>has the following parent XML elements: <see cref="maps" />.</description></item>
+        /// <item><description>has the following XML attributes: <see cref="NoNamespace.dimension" />, <see cref="NoNamespace.measureGroup" />.</description></item>
+        /// <item><description>corresponds to the following strongly-typed classes: MeasureDimensionMap.</description></item>
+        /// </list>
+        /// </remarks>
+        public static readonly XName map = x + "map";
 
         /// <summary>
         /// Represents the x:MapInfo XML element.


### PR DESCRIPTION
Without this, the current culture is used. Since .NET Framework and .NET Core use different data sources for culture sorting, this caused differences from the CLI and VS. This should keep the generated source consistent across toolchains.
