### PR TITLE
Make part/package constructors internal

### DIFF
--- a/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Parts/PartWriter.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Parts/PartWriter.cs
@@ -483,7 +483,7 @@ public static class PartWriter
         yield return new(ItemType.Constructor, string.Empty, writer =>
         {
             writer.WriteDocumentationComment($"Creates an instance of the {type.Name} OpenXmlType");
-            writer.Write("internal protected ");
+            writer.Write("internal ");
             writer.Write(type.Name);
             writer.WriteLine("()");
             writer.WriteLine("{");

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_AlternativeFormatImportPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_AlternativeFormatImportPart.cs
@@ -22,7 +22,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the AlternativeFormatImportPart OpenXmlType
         /// </summary>
-        internal protected AlternativeFormatImportPart()
+        internal AlternativeFormatImportPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CalculationChainPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CalculationChainPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the CalculationChainPart OpenXmlType
         /// </summary>
-        internal protected CalculationChainPart()
+        internal CalculationChainPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CellMetadataPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CellMetadataPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the CellMetadataPart OpenXmlType
         /// </summary>
-        internal protected CellMetadataPart()
+        internal CellMetadataPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ChartColorStylePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ChartColorStylePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ChartColorStylePart OpenXmlType
         /// </summary>
-        internal protected ChartColorStylePart()
+        internal ChartColorStylePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ChartDrawingPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ChartDrawingPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ChartDrawingPart OpenXmlType
         /// </summary>
-        internal protected ChartDrawingPart()
+        internal ChartDrawingPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ChartPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ChartPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ChartPart OpenXmlType
         /// </summary>
-        internal protected ChartPart()
+        internal ChartPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ChartStylePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ChartStylePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ChartStylePart OpenXmlType
         /// </summary>
-        internal protected ChartStylePart()
+        internal ChartStylePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ChartsheetPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ChartsheetPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ChartsheetPart OpenXmlType
         /// </summary>
-        internal protected ChartsheetPart()
+        internal ChartsheetPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CommentAuthorsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CommentAuthorsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the CommentAuthorsPart OpenXmlType
         /// </summary>
-        internal protected CommentAuthorsPart()
+        internal CommentAuthorsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ConnectionsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ConnectionsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ConnectionsPart OpenXmlType
         /// </summary>
-        internal protected ConnectionsPart()
+        internal ConnectionsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ControlPropertiesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ControlPropertiesPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ControlPropertiesPart OpenXmlType
         /// </summary>
-        internal protected ControlPropertiesPart()
+        internal ControlPropertiesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CoreFilePropertiesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CoreFilePropertiesPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the CoreFilePropertiesPart OpenXmlType
         /// </summary>
-        internal protected CoreFilePropertiesPart()
+        internal CoreFilePropertiesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomDataPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomDataPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the CustomDataPart OpenXmlType
         /// </summary>
-        internal protected CustomDataPart()
+        internal CustomDataPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomDataPropertiesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomDataPropertiesPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the CustomDataPropertiesPart OpenXmlType
         /// </summary>
-        internal protected CustomDataPropertiesPart()
+        internal CustomDataPropertiesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomFilePropertiesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomFilePropertiesPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the CustomFilePropertiesPart OpenXmlType
         /// </summary>
-        internal protected CustomFilePropertiesPart()
+        internal CustomFilePropertiesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomPropertyPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomPropertyPart.cs
@@ -22,7 +22,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the CustomPropertyPart OpenXmlType
         /// </summary>
-        internal protected CustomPropertyPart()
+        internal CustomPropertyPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomXmlMappingsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomXmlMappingsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the CustomXmlMappingsPart OpenXmlType
         /// </summary>
-        internal protected CustomXmlMappingsPart()
+        internal CustomXmlMappingsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomXmlPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomXmlPart.cs
@@ -22,7 +22,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the CustomXmlPart OpenXmlType
         /// </summary>
-        internal protected CustomXmlPart()
+        internal CustomXmlPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomXmlPropertiesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomXmlPropertiesPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the CustomXmlPropertiesPart OpenXmlType
         /// </summary>
-        internal protected CustomXmlPropertiesPart()
+        internal CustomXmlPropertiesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomizationPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomizationPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the CustomizationPart OpenXmlType
         /// </summary>
-        internal protected CustomizationPart()
+        internal CustomizationPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DiagramColorsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DiagramColorsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the DiagramColorsPart OpenXmlType
         /// </summary>
-        internal protected DiagramColorsPart()
+        internal DiagramColorsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DiagramDataPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DiagramDataPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the DiagramDataPart OpenXmlType
         /// </summary>
-        internal protected DiagramDataPart()
+        internal DiagramDataPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DiagramLayoutDefinitionPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DiagramLayoutDefinitionPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the DiagramLayoutDefinitionPart OpenXmlType
         /// </summary>
-        internal protected DiagramLayoutDefinitionPart()
+        internal DiagramLayoutDefinitionPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DiagramPersistLayoutPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DiagramPersistLayoutPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the DiagramPersistLayoutPart OpenXmlType
         /// </summary>
-        internal protected DiagramPersistLayoutPart()
+        internal DiagramPersistLayoutPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DiagramStylePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DiagramStylePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the DiagramStylePart OpenXmlType
         /// </summary>
-        internal protected DiagramStylePart()
+        internal DiagramStylePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DialogsheetPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DialogsheetPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the DialogsheetPart OpenXmlType
         /// </summary>
-        internal protected DialogsheetPart()
+        internal DialogsheetPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DigitalSignatureOriginPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DigitalSignatureOriginPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the DigitalSignatureOriginPart OpenXmlType
         /// </summary>
-        internal protected DigitalSignatureOriginPart()
+        internal DigitalSignatureOriginPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DocumentSettingsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DocumentSettingsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the DocumentSettingsPart OpenXmlType
         /// </summary>
-        internal protected DocumentSettingsPart()
+        internal DocumentSettingsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DocumentTasksPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DocumentTasksPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the DocumentTasksPart OpenXmlType
         /// </summary>
-        internal protected DocumentTasksPart()
+        internal DocumentTasksPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DrawingsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DrawingsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the DrawingsPart OpenXmlType
         /// </summary>
-        internal protected DrawingsPart()
+        internal DrawingsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_EmbeddedControlPersistenceBinaryDataPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_EmbeddedControlPersistenceBinaryDataPart.cs
@@ -22,7 +22,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the EmbeddedControlPersistenceBinaryDataPart OpenXmlType
         /// </summary>
-        internal protected EmbeddedControlPersistenceBinaryDataPart()
+        internal EmbeddedControlPersistenceBinaryDataPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_EmbeddedControlPersistencePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_EmbeddedControlPersistencePart.cs
@@ -22,7 +22,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the EmbeddedControlPersistencePart OpenXmlType
         /// </summary>
-        internal protected EmbeddedControlPersistencePart()
+        internal EmbeddedControlPersistencePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_EmbeddedObjectPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_EmbeddedObjectPart.cs
@@ -22,7 +22,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the EmbeddedObjectPart OpenXmlType
         /// </summary>
-        internal protected EmbeddedObjectPart()
+        internal EmbeddedObjectPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_EmbeddedPackagePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_EmbeddedPackagePart.cs
@@ -22,7 +22,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the EmbeddedPackagePart OpenXmlType
         /// </summary>
-        internal protected EmbeddedPackagePart()
+        internal EmbeddedPackagePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_EndnotesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_EndnotesPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the EndnotesPart OpenXmlType
         /// </summary>
-        internal protected EndnotesPart()
+        internal EndnotesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ExcelAttachedToolbarsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ExcelAttachedToolbarsPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ExcelAttachedToolbarsPart OpenXmlType
         /// </summary>
-        internal protected ExcelAttachedToolbarsPart()
+        internal ExcelAttachedToolbarsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ExtendedChartPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ExtendedChartPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ExtendedChartPart OpenXmlType
         /// </summary>
-        internal protected ExtendedChartPart()
+        internal ExtendedChartPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ExtendedFilePropertiesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ExtendedFilePropertiesPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ExtendedFilePropertiesPart OpenXmlType
         /// </summary>
-        internal protected ExtendedFilePropertiesPart()
+        internal ExtendedFilePropertiesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ExternalWorkbookPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ExternalWorkbookPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ExternalWorkbookPart OpenXmlType
         /// </summary>
-        internal protected ExternalWorkbookPart()
+        internal ExternalWorkbookPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_FontPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_FontPart.cs
@@ -22,7 +22,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the FontPart OpenXmlType
         /// </summary>
-        internal protected FontPart()
+        internal FontPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_FontTablePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_FontTablePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the FontTablePart OpenXmlType
         /// </summary>
-        internal protected FontTablePart()
+        internal FontTablePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_FooterPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_FooterPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the FooterPart OpenXmlType
         /// </summary>
-        internal protected FooterPart()
+        internal FooterPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_FootnotesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_FootnotesPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the FootnotesPart OpenXmlType
         /// </summary>
-        internal protected FootnotesPart()
+        internal FootnotesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_GlossaryDocumentPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_GlossaryDocumentPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the GlossaryDocumentPart OpenXmlType
         /// </summary>
-        internal protected GlossaryDocumentPart()
+        internal GlossaryDocumentPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_HandoutMasterPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_HandoutMasterPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the HandoutMasterPart OpenXmlType
         /// </summary>
-        internal protected HandoutMasterPart()
+        internal HandoutMasterPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_HeaderPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_HeaderPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the HeaderPart OpenXmlType
         /// </summary>
-        internal protected HeaderPart()
+        internal HeaderPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ImagePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ImagePart.cs
@@ -22,7 +22,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ImagePart OpenXmlType
         /// </summary>
-        internal protected ImagePart()
+        internal ImagePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_InternationalMacroSheetPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_InternationalMacroSheetPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the InternationalMacroSheetPart OpenXmlType
         /// </summary>
-        internal protected InternationalMacroSheetPart()
+        internal InternationalMacroSheetPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_LabelInfoPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_LabelInfoPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the LabelInfoPart OpenXmlType
         /// </summary>
-        internal protected LabelInfoPart()
+        internal LabelInfoPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_LegacyDiagramTextInfoPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_LegacyDiagramTextInfoPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the LegacyDiagramTextInfoPart OpenXmlType
         /// </summary>
-        internal protected LegacyDiagramTextInfoPart()
+        internal LegacyDiagramTextInfoPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_LegacyDiagramTextPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_LegacyDiagramTextPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the LegacyDiagramTextPart OpenXmlType
         /// </summary>
-        internal protected LegacyDiagramTextPart()
+        internal LegacyDiagramTextPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_MacroSheetPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_MacroSheetPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the MacroSheetPart OpenXmlType
         /// </summary>
-        internal protected MacroSheetPart()
+        internal MacroSheetPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_MailMergeRecipientDataPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_MailMergeRecipientDataPart.cs
@@ -22,7 +22,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the MailMergeRecipientDataPart OpenXmlType
         /// </summary>
-        internal protected MailMergeRecipientDataPart()
+        internal MailMergeRecipientDataPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_MainDocumentPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_MainDocumentPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the MainDocumentPart OpenXmlType
         /// </summary>
-        internal protected MainDocumentPart()
+        internal MainDocumentPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_Model3DReferenceRelationshipPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_Model3DReferenceRelationshipPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the Model3DReferenceRelationshipPart OpenXmlType
         /// </summary>
-        internal protected Model3DReferenceRelationshipPart()
+        internal Model3DReferenceRelationshipPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_NamedSheetViewsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_NamedSheetViewsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the NamedSheetViewsPart OpenXmlType
         /// </summary>
-        internal protected NamedSheetViewsPart()
+        internal NamedSheetViewsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_NotesMasterPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_NotesMasterPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the NotesMasterPart OpenXmlType
         /// </summary>
-        internal protected NotesMasterPart()
+        internal NotesMasterPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_NotesSlidePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_NotesSlidePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the NotesSlidePart OpenXmlType
         /// </summary>
-        internal protected NotesSlidePart()
+        internal NotesSlidePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_NumberingDefinitionsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_NumberingDefinitionsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the NumberingDefinitionsPart OpenXmlType
         /// </summary>
-        internal protected NumberingDefinitionsPart()
+        internal NumberingDefinitionsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PivotTableCacheDefinitionPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PivotTableCacheDefinitionPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the PivotTableCacheDefinitionPart OpenXmlType
         /// </summary>
-        internal protected PivotTableCacheDefinitionPart()
+        internal PivotTableCacheDefinitionPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PivotTableCacheRecordsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PivotTableCacheRecordsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the PivotTableCacheRecordsPart OpenXmlType
         /// </summary>
-        internal protected PivotTableCacheRecordsPart()
+        internal PivotTableCacheRecordsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PivotTablePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PivotTablePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the PivotTablePart OpenXmlType
         /// </summary>
-        internal protected PivotTablePart()
+        internal PivotTablePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PowerPointAuthorsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PowerPointAuthorsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the PowerPointAuthorsPart OpenXmlType
         /// </summary>
-        internal protected PowerPointAuthorsPart()
+        internal PowerPointAuthorsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PowerPointCommentPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PowerPointCommentPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the PowerPointCommentPart OpenXmlType
         /// </summary>
-        internal protected PowerPointCommentPart()
+        internal PowerPointCommentPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PresentationPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PresentationPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the PresentationPart OpenXmlType
         /// </summary>
-        internal protected PresentationPart()
+        internal PresentationPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PresentationPropertiesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PresentationPropertiesPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the PresentationPropertiesPart OpenXmlType
         /// </summary>
-        internal protected PresentationPropertiesPart()
+        internal PresentationPropertiesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_QueryTablePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_QueryTablePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the QueryTablePart OpenXmlType
         /// </summary>
-        internal protected QueryTablePart()
+        internal QueryTablePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_QuickAccessToolbarCustomizationsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_QuickAccessToolbarCustomizationsPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the QuickAccessToolbarCustomizationsPart OpenXmlType
         /// </summary>
-        internal protected QuickAccessToolbarCustomizationsPart()
+        internal QuickAccessToolbarCustomizationsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdArrayPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdArrayPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the RdArrayPart OpenXmlType
         /// </summary>
-        internal protected RdArrayPart()
+        internal RdArrayPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdRichValuePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdRichValuePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the RdRichValuePart OpenXmlType
         /// </summary>
-        internal protected RdRichValuePart()
+        internal RdRichValuePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdRichValueStructurePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdRichValueStructurePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the RdRichValueStructurePart OpenXmlType
         /// </summary>
-        internal protected RdRichValueStructurePart()
+        internal RdRichValueStructurePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdRichValueTypesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdRichValueTypesPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the RdRichValueTypesPart OpenXmlType
         /// </summary>
-        internal protected RdRichValueTypesPart()
+        internal RdRichValueTypesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdRichValueWebImagePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdRichValueWebImagePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the RdRichValueWebImagePart OpenXmlType
         /// </summary>
-        internal protected RdRichValueWebImagePart()
+        internal RdRichValueWebImagePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdSupportingPropertyBagPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdSupportingPropertyBagPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the RdSupportingPropertyBagPart OpenXmlType
         /// </summary>
-        internal protected RdSupportingPropertyBagPart()
+        internal RdSupportingPropertyBagPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdSupportingPropertyBagStructurePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdSupportingPropertyBagStructurePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the RdSupportingPropertyBagStructurePart OpenXmlType
         /// </summary>
-        internal protected RdSupportingPropertyBagStructurePart()
+        internal RdSupportingPropertyBagStructurePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RibbonAndBackstageCustomizationsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RibbonAndBackstageCustomizationsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the RibbonAndBackstageCustomizationsPart OpenXmlType
         /// </summary>
-        internal protected RibbonAndBackstageCustomizationsPart()
+        internal RibbonAndBackstageCustomizationsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RibbonExtensibilityPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RibbonExtensibilityPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the RibbonExtensibilityPart OpenXmlType
         /// </summary>
-        internal protected RibbonExtensibilityPart()
+        internal RibbonExtensibilityPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RichStylesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RichStylesPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the RichStylesPart OpenXmlType
         /// </summary>
-        internal protected RichStylesPart()
+        internal RichStylesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SharedStringTablePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SharedStringTablePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the SharedStringTablePart OpenXmlType
         /// </summary>
-        internal protected SharedStringTablePart()
+        internal SharedStringTablePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SingleCellTablePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SingleCellTablePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the SingleCellTablePart OpenXmlType
         /// </summary>
-        internal protected SingleCellTablePart()
+        internal SingleCellTablePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlicerCachePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlicerCachePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the SlicerCachePart OpenXmlType
         /// </summary>
-        internal protected SlicerCachePart()
+        internal SlicerCachePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlicersPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlicersPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the SlicersPart OpenXmlType
         /// </summary>
-        internal protected SlicersPart()
+        internal SlicersPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlideCommentsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlideCommentsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the SlideCommentsPart OpenXmlType
         /// </summary>
-        internal protected SlideCommentsPart()
+        internal SlideCommentsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlideLayoutPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlideLayoutPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the SlideLayoutPart OpenXmlType
         /// </summary>
-        internal protected SlideLayoutPart()
+        internal SlideLayoutPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlideMasterPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlideMasterPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the SlideMasterPart OpenXmlType
         /// </summary>
-        internal protected SlideMasterPart()
+        internal SlideMasterPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlidePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlidePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the SlidePart OpenXmlType
         /// </summary>
-        internal protected SlidePart()
+        internal SlidePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlideSyncDataPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlideSyncDataPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the SlideSyncDataPart OpenXmlType
         /// </summary>
-        internal protected SlideSyncDataPart()
+        internal SlideSyncDataPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SpreadsheetPrinterSettingsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SpreadsheetPrinterSettingsPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the SpreadsheetPrinterSettingsPart OpenXmlType
         /// </summary>
-        internal protected SpreadsheetPrinterSettingsPart()
+        internal SpreadsheetPrinterSettingsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_StyleDefinitionsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_StyleDefinitionsPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the StyleDefinitionsPart OpenXmlType
         /// </summary>
-        internal protected StyleDefinitionsPart()
+        internal StyleDefinitionsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_StylesWithEffectsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_StylesWithEffectsPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the StylesWithEffectsPart OpenXmlType
         /// </summary>
-        internal protected StylesWithEffectsPart()
+        internal StylesWithEffectsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_TableDefinitionPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_TableDefinitionPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the TableDefinitionPart OpenXmlType
         /// </summary>
-        internal protected TableDefinitionPart()
+        internal TableDefinitionPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_TableStylesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_TableStylesPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the TableStylesPart OpenXmlType
         /// </summary>
-        internal protected TableStylesPart()
+        internal TableStylesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ThemeOverridePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ThemeOverridePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ThemeOverridePart OpenXmlType
         /// </summary>
-        internal protected ThemeOverridePart()
+        internal ThemeOverridePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ThemePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ThemePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ThemePart OpenXmlType
         /// </summary>
-        internal protected ThemePart()
+        internal ThemePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ThumbnailPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ThumbnailPart.cs
@@ -22,7 +22,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ThumbnailPart OpenXmlType
         /// </summary>
-        internal protected ThumbnailPart()
+        internal ThumbnailPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_TimeLineCachePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_TimeLineCachePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the TimeLineCachePart OpenXmlType
         /// </summary>
-        internal protected TimeLineCachePart()
+        internal TimeLineCachePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_TimeLinePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_TimeLinePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the TimeLinePart OpenXmlType
         /// </summary>
-        internal protected TimeLinePart()
+        internal TimeLinePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_UserDefinedTagsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_UserDefinedTagsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the UserDefinedTagsPart OpenXmlType
         /// </summary>
-        internal protected UserDefinedTagsPart()
+        internal UserDefinedTagsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_VbaDataPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_VbaDataPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the VbaDataPart OpenXmlType
         /// </summary>
-        internal protected VbaDataPart()
+        internal VbaDataPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_VbaProjectPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_VbaProjectPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the VbaProjectPart OpenXmlType
         /// </summary>
-        internal protected VbaProjectPart()
+        internal VbaProjectPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ViewPropertiesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ViewPropertiesPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the ViewPropertiesPart OpenXmlType
         /// </summary>
-        internal protected ViewPropertiesPart()
+        internal ViewPropertiesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_VmlDrawingPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_VmlDrawingPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the VmlDrawingPart OpenXmlType
         /// </summary>
-        internal protected VmlDrawingPart()
+        internal VmlDrawingPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_VolatileDependenciesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_VolatileDependenciesPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the VolatileDependenciesPart OpenXmlType
         /// </summary>
-        internal protected VolatileDependenciesPart()
+        internal VolatileDependenciesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WebExTaskpanesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WebExTaskpanesPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WebExTaskpanesPart OpenXmlType
         /// </summary>
-        internal protected WebExTaskpanesPart()
+        internal WebExTaskpanesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WebExtensionPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WebExtensionPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WebExtensionPart OpenXmlType
         /// </summary>
-        internal protected WebExtensionPart()
+        internal WebExtensionPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WebSettingsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WebSettingsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WebSettingsPart OpenXmlType
         /// </summary>
-        internal protected WebSettingsPart()
+        internal WebSettingsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordAttachedToolbarsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordAttachedToolbarsPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WordAttachedToolbarsPart OpenXmlType
         /// </summary>
-        internal protected WordAttachedToolbarsPart()
+        internal WordAttachedToolbarsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordCommentsExtensiblePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordCommentsExtensiblePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WordCommentsExtensiblePart OpenXmlType
         /// </summary>
-        internal protected WordCommentsExtensiblePart()
+        internal WordCommentsExtensiblePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingCommentsExPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingCommentsExPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WordprocessingCommentsExPart OpenXmlType
         /// </summary>
-        internal protected WordprocessingCommentsExPart()
+        internal WordprocessingCommentsExPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingCommentsIdsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingCommentsIdsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WordprocessingCommentsIdsPart OpenXmlType
         /// </summary>
-        internal protected WordprocessingCommentsIdsPart()
+        internal WordprocessingCommentsIdsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingCommentsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingCommentsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WordprocessingCommentsPart OpenXmlType
         /// </summary>
-        internal protected WordprocessingCommentsPart()
+        internal WordprocessingCommentsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingPeoplePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingPeoplePart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WordprocessingPeoplePart OpenXmlType
         /// </summary>
-        internal protected WordprocessingPeoplePart()
+        internal WordprocessingPeoplePart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingPrinterSettingsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingPrinterSettingsPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WordprocessingPrinterSettingsPart OpenXmlType
         /// </summary>
-        internal protected WordprocessingPrinterSettingsPart()
+        internal WordprocessingPrinterSettingsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookPart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WorkbookPart OpenXmlType
         /// </summary>
-        internal protected WorkbookPart()
+        internal WorkbookPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookPersonPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookPersonPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WorkbookPersonPart OpenXmlType
         /// </summary>
-        internal protected WorkbookPersonPart()
+        internal WorkbookPersonPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookRevisionHeaderPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookRevisionHeaderPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WorkbookRevisionHeaderPart OpenXmlType
         /// </summary>
-        internal protected WorkbookRevisionHeaderPart()
+        internal WorkbookRevisionHeaderPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookRevisionLogPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookRevisionLogPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WorkbookRevisionLogPart OpenXmlType
         /// </summary>
-        internal protected WorkbookRevisionLogPart()
+        internal WorkbookRevisionLogPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookStylesPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookStylesPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WorkbookStylesPart OpenXmlType
         /// </summary>
-        internal protected WorkbookStylesPart()
+        internal WorkbookStylesPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookUserDataPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookUserDataPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WorkbookUserDataPart OpenXmlType
         /// </summary>
-        internal protected WorkbookUserDataPart()
+        internal WorkbookUserDataPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorksheetCommentsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorksheetCommentsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WorksheetCommentsPart OpenXmlType
         /// </summary>
-        internal protected WorksheetCommentsPart()
+        internal WorksheetCommentsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorksheetPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorksheetPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WorksheetPart OpenXmlType
         /// </summary>
-        internal protected WorksheetPart()
+        internal WorksheetPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorksheetSortMapPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorksheetSortMapPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WorksheetSortMapPart OpenXmlType
         /// </summary>
-        internal protected WorksheetSortMapPart()
+        internal WorksheetSortMapPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorksheetThreadedCommentsPart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorksheetThreadedCommentsPart.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the WorksheetThreadedCommentsPart OpenXmlType
         /// </summary>
-        internal protected WorksheetThreadedCommentsPart()
+        internal WorksheetThreadedCommentsPart()
         {
         }
 

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_XmlSignaturePart.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_XmlSignaturePart.cs
@@ -23,7 +23,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Creates an instance of the XmlSignaturePart OpenXmlType
         /// </summary>
-        internal protected XmlSignaturePart()
+        internal XmlSignaturePart()
         {
         }
 

--- a/samples/DocumentTaskExample/Program.cs
+++ b/samples/DocumentTaskExample/Program.cs
@@ -18,6 +18,10 @@ namespace DocumentTaskSample
     {
         private static void Main(string[] args)
         {
+            var types = typeof(SpreadsheetDocument).Assembly.GetTypes().Where(t => t.IsAssignableTo(typeof(OpenXmlPartContainer))).ToList();
+            var publi = types.Where(t => t.GetConstructors().Any(c => c.IsPublic)).ToList();
+
+
             if (args.Length < 1)
             {
                 Common.ExampleUtilities.ShowHelp(

--- a/samples/DocumentTaskExample/Program.cs
+++ b/samples/DocumentTaskExample/Program.cs
@@ -18,10 +18,6 @@ namespace DocumentTaskSample
     {
         private static void Main(string[] args)
         {
-            var types = typeof(SpreadsheetDocument).Assembly.GetTypes().Where(t => t.IsAssignableTo(typeof(OpenXmlPartContainer))).ToList();
-            var publi = types.Where(t => t.GetConstructors().Any(c => c.IsPublic)).ToList();
-
-
             if (args.Length < 1)
             {
                 Common.ExampleUtilities.ShowHelp(

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/ExtendedPart.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/ExtendedPart.cs
@@ -15,7 +15,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// Initialize a new instance of ExtendedPart.
         /// </summary>
         /// <param name="relationshipType"></param>
-        internal protected ExtendedPart(string relationshipType)
+        internal ExtendedPart(string relationshipType)
             : base()
         {
             RelationshipType = relationshipType;

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPackage.cs
@@ -24,7 +24,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Initializes a new instance of the OpenXmlPackage class.
         /// </summary>
-        protected OpenXmlPackage()
+        private protected OpenXmlPackage()
             : base()
         {
         }

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPart.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPart.cs
@@ -22,7 +22,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// <summary>
         /// Create an instance of <see cref="OpenXmlPart"/>
         /// </summary>
-        protected OpenXmlPart()
+        private protected OpenXmlPart()
             : base()
         {
         }

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPartContainer.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPartContainer.cs
@@ -26,7 +26,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// Initializes OpenXmlPartContainer.
         /// </summary>
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Registered to be disposed with container")]
-        protected OpenXmlPartContainer()
+        private protected OpenXmlPartContainer()
         {
             var childFeatures = new PartRelationshipsFeature(this);
 


### PR DESCRIPTION
We'll look at making these public again at some point (especially if people need them for some reason), but at the moment I don't think anyone would be overriding things since they have internal abstract methods. This will allow us to play around with their construction a bit more without requiring a public constructor we have to enable to work.

Fixes #1272 
