### PR TITLE
Allow null values via annotation to operator overloads able to handle null

### DIFF
--- a/src/DocumentFormat.OpenXml.Framework/SimpleTypes/Base64BinaryValue.cs
+++ b/src/DocumentFormat.OpenXml.Framework/SimpleTypes/Base64BinaryValue.cs
@@ -100,7 +100,7 @@ namespace DocumentFormat.OpenXml
         /// </summary>
         /// <param name="value">The <see cref="Base64BinaryValue"/> object to convert.</param>
         /// <returns>The base64Binary string. Returns null when <paramref name="value"/> is <c>null</c>.</returns>
-        public static implicit operator string?(Base64BinaryValue value)
+        public static implicit operator string?(Base64BinaryValue? value)
         {
             if (value is null)
             {

--- a/src/DocumentFormat.OpenXml.Framework/SimpleTypes/EnumValue.cs
+++ b/src/DocumentFormat.OpenXml.Framework/SimpleTypes/EnumValue.cs
@@ -83,7 +83,7 @@ namespace DocumentFormat.OpenXml
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>The converted string.</returns>
-        public static implicit operator string?(EnumValue<T> value)
+        public static implicit operator string?(EnumValue<T>? value)
         {
             if (value is null)
             {

--- a/src/DocumentFormat.OpenXml.Framework/SimpleTypes/OpenXmlComparableSimpleValue.cs
+++ b/src/DocumentFormat.OpenXml.Framework/SimpleTypes/OpenXmlComparableSimpleValue.cs
@@ -125,7 +125,7 @@ namespace DocumentFormat.OpenXml
         /// <param name="left">The left operand, or null.</param>
         /// <param name="right">The right operand, or null.</param>
         /// <returns>True if the operands are equal; otherwise, false.</returns>
-        public static bool operator ==(OpenXmlComparableSimpleValue<T> left, OpenXmlComparableSimpleValue<T> right)
+        public static bool operator ==(OpenXmlComparableSimpleValue<T>? left, OpenXmlComparableSimpleValue<T>? right)
         {
             if (left is null)
             {
@@ -141,7 +141,7 @@ namespace DocumentFormat.OpenXml
         /// <param name="left">The left operand, or null.</param>
         /// <param name="right">The right operand, or null.</param>
         /// <returns>True if the operands are not equal; otherwise, false.</returns>
-        public static bool operator !=(OpenXmlComparableSimpleValue<T> left, OpenXmlComparableSimpleValue<T> right)
+        public static bool operator !=(OpenXmlComparableSimpleValue<T>? left, OpenXmlComparableSimpleValue<T>? right)
         {
             return !(left == right);
         }
@@ -152,7 +152,7 @@ namespace DocumentFormat.OpenXml
         /// <param name="left">The left operand, or null.</param>
         /// <param name="right">The right operand, or null.</param>
         /// <returns>True if the left operand is less than the right operand; otherwise, false.</returns>
-        public static bool operator <(OpenXmlComparableSimpleValue<T> left, OpenXmlComparableSimpleValue<T> right)
+        public static bool operator <(OpenXmlComparableSimpleValue<T>? left, OpenXmlComparableSimpleValue<T>? right)
         {
             return left is null ? !(right is null) : left.CompareTo(right) < 0;
         }
@@ -163,7 +163,7 @@ namespace DocumentFormat.OpenXml
         /// <param name="left">The left operand, or null.</param>
         /// <param name="right">The right operand, or null.</param>
         /// <returns>True if the left operand is less than or equal to the right operand; otherwise, false.</returns>
-        public static bool operator <=(OpenXmlComparableSimpleValue<T> left, OpenXmlComparableSimpleValue<T> right)
+        public static bool operator <=(OpenXmlComparableSimpleValue<T>? left, OpenXmlComparableSimpleValue<T>? right)
         {
             return left is null || left.CompareTo(right) <= 0;
         }
@@ -174,7 +174,7 @@ namespace DocumentFormat.OpenXml
         /// <param name="left">The left operand, or null.</param>
         /// <param name="right">The right operand, or null.</param>
         /// <returns>True if the left operand is greater than the right operand; otherwise, false.</returns>
-        public static bool operator >(OpenXmlComparableSimpleValue<T> left, OpenXmlComparableSimpleValue<T> right)
+        public static bool operator >(OpenXmlComparableSimpleValue<T>? left, OpenXmlComparableSimpleValue<T>? right)
         {
             return !(left is null) && left.CompareTo(right) > 0;
         }


### PR DESCRIPTION
While investigating enabling nullable annotations in [ClosedXml](https://github.com/ClosedXML/ClosedXML) I came across some problems with code like so (simplified and manually created to demonstrate):

```c#
var properties = new SheetFormatProperties();
DoubleValue? openXmlComparableSimpleValue = properties.DefaultRowHeight;
if (openXmlComparableSimpleValue != null)
{
    return;
}
```

Gives: `Possible null reference argument for parameter 'left' in 'DocumentFormat.OpenXml.OpenXmlComparableSimpleValue<T>.operator !='` 

I went through operator overloads and annotated ones allowing null values with `?` when input as null is handled properly.