### PR TITLE
Expose IPackage and related APIs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,6 +20,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Experimental APIs currently use obsolete messages -->
+    <NoWarn>$(NoWarn);CS0436;OOXML0001</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <IncludeSourceGenerator>false</IncludeSourceGenerator>
   </PropertyGroup>
 

--- a/docs/Diagnostics.md
+++ b/docs/Diagnostics.md
@@ -1,0 +1,3 @@
+# OOXML0001 - IPackage related APIs are currently experimental
+
+As of v3.0, a new abstraction layer was added in between `System.IO.Packaging` and `DocumentFormat.OpenXml.Packaging.OpenXmlPackage`. This is currently experimental, but can be used if needed. This will be stabalized in a future release, and may or may not require code changes.

--- a/src/DocumentFormat.OpenXml.Framework/DiagnosticIds.cs
+++ b/src/DocumentFormat.OpenXml.Framework/DiagnosticIds.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DocumentFormat.OpenXml;
+
+internal static class ExperimentalApis
+{
+    internal const string UrlFormat = "https://github.com/dotnet/open-xml-sdk/blobl/main/docs/Diagnostics.md#{0}";
+
+    internal static class PackageApis
+    {
+        public const string DiagnosticId = "OOXML0001";
+        public const string Message = "IPackage related APIs are currently experimental. Future versions may (or may not) change their shape before stabalizing.";
+    }
+}

--- a/src/DocumentFormat.OpenXml.Framework/Features/PackageFeatureBase.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/PackageFeatureBase.cs
@@ -13,7 +13,7 @@ using System.IO.Packaging;
 
 namespace DocumentFormat.OpenXml.Features;
 
-internal abstract class PackageFeatureBase : IPackage, IPackageFeature, IRelationshipFilterFeature
+internal abstract class PackageFeatureBase : IPackage, IPackageFeature, IRelationshipFilterFeature, IPackageProperties
 {
     private RelationshipCollection? _relationships;
     private Action<PackageRelationshipBuilder>? _relationshipFilter;
@@ -139,6 +139,40 @@ internal abstract class PackageFeatureBase : IPackage, IPackageFeature, IRelatio
 
     void IRelationshipFilterFeature.AddFilter(Action<PackageRelationshipBuilder> action)
         => _relationshipFilter += action;
+
+    IPackageProperties IPackage.PackageProperties => this;
+
+    string? IPackageProperties.Title { get => Package.PackageProperties.Title; set => Package.PackageProperties.Title = value; }
+
+    string? IPackageProperties.Subject { get => Package.PackageProperties.Subject; set => Package.PackageProperties.Subject = value; }
+
+    string? IPackageProperties.Creator { get => Package.PackageProperties.Creator; set => Package.PackageProperties.Creator = value; }
+
+    string? IPackageProperties.Keywords { get => Package.PackageProperties.Keywords; set => Package.PackageProperties.Keywords = value; }
+
+    string? IPackageProperties.Description { get => Package.PackageProperties.Description; set => Package.PackageProperties.Description = value; }
+
+    string? IPackageProperties.LastModifiedBy { get => Package.PackageProperties.LastModifiedBy; set => Package.PackageProperties.LastModifiedBy = value; }
+
+    string? IPackageProperties.Revision { get => Package.PackageProperties.Revision; set => Package.PackageProperties.Revision = value; }
+
+    DateTime? IPackageProperties.LastPrinted { get => Package.PackageProperties.LastPrinted; set => Package.PackageProperties.LastPrinted = value; }
+
+    DateTime? IPackageProperties.Created { get => Package.PackageProperties.Created; set => Package.PackageProperties.Created = value; }
+
+    DateTime? IPackageProperties.Modified { get => Package.PackageProperties.Modified; set => Package.PackageProperties.Modified = value; }
+
+    string? IPackageProperties.Category { get => Package.PackageProperties.Category; set => Package.PackageProperties.Category = value; }
+
+    string? IPackageProperties.Identifier { get => Package.PackageProperties.Identifier; set => Package.PackageProperties.Identifier = value; }
+
+    string? IPackageProperties.ContentType { get => Package.PackageProperties.ContentType; set => Package.PackageProperties.ContentType = value; }
+
+    string? IPackageProperties.Language { get => Package.PackageProperties.Language; set => Package.PackageProperties.Language = value; }
+
+    string? IPackageProperties.Version { get => Package.PackageProperties.Version; set => Package.PackageProperties.Version = value; }
+
+    string? IPackageProperties.ContentStatus { get => Package.PackageProperties.ContentStatus; set => Package.PackageProperties.ContentStatus = value; }
 
     private sealed class PackagePart : IPackagePart
     {

--- a/src/DocumentFormat.OpenXml.Framework/Features/PackageFeatureBase.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/PackageFeatureBase.cs
@@ -161,8 +161,6 @@ internal abstract class PackageFeatureBase : IPackage, IPackageFeature, IRelatio
 
         public IRelationshipCollection Relationships => _relationships;
 
-        public IReadOnlyCollection<IPackageRelationship> GetRelationships() => _relationships;
-
         public Stream GetStream(FileMode open, FileAccess write)
             => Part.GetStream(open, write);
     }

--- a/src/DocumentFormat.OpenXml.Framework/FileFormatVersionExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/FileFormatVersionExtensions.cs
@@ -3,6 +3,7 @@
 
 using DocumentFormat.OpenXml.Packaging;
 using System;
+using System.Globalization;
 
 namespace DocumentFormat.OpenXml
 {
@@ -205,7 +206,9 @@ namespace DocumentFormat.OpenXml
 
         private static string GetOfficeYear(this FileFormatVersions version)
         {
+#pragma warning disable CA1305
             return version.ToString().Substring("Office".Length);
+#pragma warning restore CA1305
         }
     }
 }

--- a/src/DocumentFormat.OpenXml.Framework/OpenXmlMiscNode.cs
+++ b/src/DocumentFormat.OpenXml.Framework/OpenXmlMiscNode.cs
@@ -323,7 +323,6 @@ namespace DocumentFormat.OpenXml
                 case XmlNodeType.DocumentFragment:
                 case XmlNodeType.EndEntity:
                 default:
-                    Debug.Assert(false, xmlReader.NodeType.ToString());
                     break;
             }
         }

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/Builder/DelegatingPackageFeature.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/Builder/DelegatingPackageFeature.cs
@@ -22,7 +22,7 @@ internal abstract class DelegatingPackageFeature : IPackage, IPackageFeature
 
     public virtual FileAccess FileOpenAccess => Package.FileOpenAccess;
 
-    public virtual PackageProperties PackageProperties => Package.PackageProperties;
+    public virtual IPackageProperties PackageProperties => Package.PackageProperties;
 
     IPackage IPackageFeature.Package => this;
 

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/IPackage.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/IPackage.cs
@@ -11,7 +11,8 @@ namespace DocumentFormat.OpenXml.Packaging;
 /// <summary>
 /// An abstraction similar to <see cref="System.IO.Packaging.Package"/> that allows for pass through implementations
 /// </summary>
-internal interface IPackage
+[Obsolete(ExperimentalApis.PackageApis.Message, DiagnosticId = ExperimentalApis.PackageApis.DiagnosticId, UrlFormat = ExperimentalApis.UrlFormat)]
+public interface IPackage
 {
     /// <summary>
     /// Gets the file access of the package

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/IPackage.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/IPackage.cs
@@ -22,7 +22,7 @@ public interface IPackage
     /// <summary>
     /// Gets the core properties of the package
     /// </summary>
-    PackageProperties PackageProperties { get; }
+    IPackageProperties PackageProperties { get; }
 
     /// <summary>
     /// Returns a collection of parts for the package

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/IPackagePart.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/IPackagePart.cs
@@ -9,7 +9,8 @@ namespace DocumentFormat.OpenXml.Packaging;
 /// <summary>
 /// An abstraction for <see cref="System.IO.Packaging.PackagePart"/> that is easier to override.
 /// </summary>
-internal interface IPackagePart
+[Obsolete(ExperimentalApis.PackageApis.Message, DiagnosticId = ExperimentalApis.PackageApis.DiagnosticId, UrlFormat = ExperimentalApis.UrlFormat)]
+public interface IPackagePart
 {
     /// <summary>
     /// Gets a reference to the containing package.

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/IPackageProperties.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/IPackageProperties.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DocumentFormat.OpenXml.Packaging;
+
+/// <summary>
+/// An abstraction of package properties, similar to <see cref="System.IO.Packaging.PackageProperties"/>.
+/// </summary>
+[Obsolete(ExperimentalApis.PackageApis.Message, DiagnosticId = ExperimentalApis.PackageApis.DiagnosticId, UrlFormat = ExperimentalApis.UrlFormat)]
+public interface IPackageProperties
+{
+    /// <summary>
+    /// Gets or sets the title.
+    /// </summary>
+    string? Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets the topic of the contents.
+    /// </summary>
+    string? Subject { get; set; }
+
+    /// <summary>
+    /// Gets or sets the primary creator. The identification is environment-specific and
+    /// can consist of a name, email address, employee ID, etc. It is
+    /// recommended that this value be only as verbose as necessary to
+    /// identify the individual.
+    /// </summary>
+    string? Creator { get; set; }
+
+    /// <summary>
+    /// Gets or sets a delimited set of keywords to support searching and indexing. This
+    /// is typically a list of terms that are not available elsewhere in the
+    /// properties.
+    /// </summary>
+    string? Keywords { get; set; }
+
+    /// <summary>
+    /// Gets or sets the description or abstract of the contents.
+    /// </summary>
+    string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user who performed the last modification. The identification is
+    /// environment-specific and can consist of a name, email address,
+    /// employee ID, etc. It is recommended that this value be only as
+    /// verbose as necessary to identify the individual.
+    /// </summary>
+    string? LastModifiedBy { get; set; }
+
+    /// <summary>
+    /// Gets or sets the revision number. This value indicates the number of saves or
+    /// revisions. The application is responsible for updating this value
+    /// after each revision.
+    /// </summary>
+    string? Revision { get; set; }
+
+    /// <summary>
+    /// Gets or sets the date and time of the last printing.
+    /// </summary>
+    DateTime? LastPrinted { get; set; }
+
+    /// <summary>
+    /// Gets or sets the creation date and time.
+    /// </summary>
+    DateTime? Created { get; set; }
+
+    /// <summary>
+    /// Gets or sets the date and time of the last modification.
+    /// </summary>
+    DateTime? Modified { get; set; }
+
+    /// <summary>
+    /// Gets or sets the category.
+    /// </summary>
+    string? Category { get; set; }
+
+    /// <summary>
+    /// Gets or sets a unique identifier.
+    /// </summary>
+    string? Identifier { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of content represented, generally defined by a specific
+    /// use and intended audience. Example values include "Whitepaper",
+    /// "Security Bulletin", and "Exam". (This property is distinct from
+    /// MIME content types as defined in RFC 2045.)
+    /// </summary>
+    string? ContentType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the primary language of the package content. The language tag is
+    /// composed of one or more parts: A primary language subtag and a
+    /// (possibly empty) series of subsequent subtags, for example, "EN-US".
+    /// These values MUST follow the convention specified in RFC 3066.
+    /// </summary>
+    string? Language { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version number. This value is set by the user or by the application.
+    /// </summary>
+    string? Version { get; set; }
+
+    /// <summary>
+    /// Gets or sets the status of the content. Example values include "Draft", "Reviewed", and "Final".
+    /// </summary>
+    string? ContentStatus { get; set; }
+}

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/IPackageRelationship.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/IPackageRelationship.cs
@@ -9,7 +9,8 @@ namespace DocumentFormat.OpenXml.Packaging;
 /// <summary>
 /// An interface that defines the relationship between a source and a target part. Similar to <see cref="PackageRelationship"/> but allows full overriding.
 /// </summary>
-internal interface IPackageRelationship
+[Obsolete(ExperimentalApis.PackageApis.Message, DiagnosticId = ExperimentalApis.PackageApis.DiagnosticId, UrlFormat = ExperimentalApis.UrlFormat)]
+public interface IPackageRelationship
 {
     /// <summary>
     /// Gets a unique identifier across relationships for the given source.

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/IRelationshipCollection.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/IRelationshipCollection.cs
@@ -7,7 +7,11 @@ using System.IO.Packaging;
 
 namespace DocumentFormat.OpenXml.Packaging;
 
-internal interface IRelationshipCollection : IEnumerable<IPackageRelationship>, IReadOnlyCollection<IPackageRelationship>
+/// <summary>
+/// A collection of relationships for a <see cref="IPackage"/> of <see cref="IPackagePart"/>.
+/// </summary>
+[Obsolete(ExperimentalApis.PackageApis.Message, DiagnosticId = ExperimentalApis.PackageApis.DiagnosticId, UrlFormat = ExperimentalApis.UrlFormat)]
+public interface IRelationshipCollection : IEnumerable<IPackageRelationship>
 {
     /// <summary>
     /// Creates a relationship to a part with a given URI, target mode, relationship type, and (optional) identifier.
@@ -31,6 +35,11 @@ internal interface IRelationshipCollection : IEnumerable<IPackageRelationship>, 
     /// <param name="id">Id of relationship</param>
     /// <returns>A package relationship</returns>
     IPackageRelationship this[string id] { get; }
+
+    /// <summary>
+    /// Gets a count of the registered relationships.
+    /// </summary>
+    public int Count { get; }
 
     /// <summary>
     /// Indicates whether a relationship with a given ID is defined.

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPackage.cs
@@ -54,11 +54,6 @@ namespace DocumentFormat.OpenXml.Packaging
         public FileAccess FileOpenAccess => Package.FileOpenAccess;
 
         /// <summary>
-        /// Gets the core package properties of the Open XML document.
-        /// </summary>
-        public PackageProperties PackageProperties => Package.PackageProperties;
-
-        /// <summary>
         /// Gets or sets the compression level for the content of the new part
         /// </summary>
         public CompressionOption CompressionOption { get; set; } = CompressionOption.Normal;

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPackage.cs
@@ -48,6 +48,11 @@ namespace DocumentFormat.OpenXml.Packaging
         internal IPackage Package => Features.GetRequired<IPackageFeature>().Package;
 
         /// <summary>
+        /// Gets the package properties.
+        /// </summary>
+        public IPackageProperties PackageProperties => Features.GetRequired<IPackageFeature>().Package.PackageProperties;
+
+        /// <summary>
         /// Gets the FileAccess setting for the document.
         /// The current I/O access settings are: Read, Write, or ReadWrite.
         /// </summary>

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/PackageExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/PackageExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Features;
+using DocumentFormat.OpenXml.Packaging;
+using System;
+
+namespace DocumentFormat.OpenXml.Experimental;
+
+/// <summary>
+/// Extensions to retrieve package details.
+/// </summary>
+[Obsolete(ExperimentalApis.PackageApis.Message, DiagnosticId = ExperimentalApis.PackageApis.DiagnosticId, UrlFormat = ExperimentalApis.UrlFormat)]
+public static class PackageExtensions
+{
+    /// <summary>
+    /// [EXPERIMENTAL] Gets the current <see cref="IPackage"/> for the <paramref name="package"/>.
+    /// </summary>
+    /// <param name="package">Current package.</param>
+    /// <returns>The underlying <see cref="IPackage"/>.</returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="package"/> is <c>null</c>.</exception>
+    public static IPackage GetPackage(this OpenXmlPackage package)
+    {
+        if (package is null)
+        {
+            throw new ArgumentNullException(nameof(package));
+        }
+
+        return package.Features.GetRequired<IPackageFeature>().Package;
+    }
+}

--- a/src/common/FrameworkShims.targets
+++ b/src/common/FrameworkShims.targets
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ShimFile Include="$(MSBuildThisFileDirectory)System\IO\StreamReadExtensions.cs" />
     <ShimFile Include="$(MSBuildThisFileDirectory)System\EnumExtensions.cs" />
+    <ShimFile Include="$(MSBuildThisFileDirectory)System\ObsoleteAttribute.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">

--- a/src/common/System/ObsoleteAttribute.cs
+++ b/src/common/System/ObsoleteAttribute.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !NET5_0_OR_GREATER
+
+namespace System;
+
+#pragma warning disable CA1019
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Delegate, Inherited = false)]
+internal sealed class ObsoleteAttribute : Attribute
+{
+    public ObsoleteAttribute()
+    {
+    }
+
+    public ObsoleteAttribute(string? message)
+    {
+        Message = message;
+    }
+
+    public ObsoleteAttribute(string? message, bool error)
+    {
+        Message = message;
+        IsError = error;
+    }
+
+    public string? Message { get; }
+
+    public bool IsError { get; }
+
+    public string? DiagnosticId { get; set; }
+
+    public string? UrlFormat { get; set; }
+}
+
+#endif


### PR DESCRIPTION
This will enable users to retrieve the underlying package, but it is marked as experimental using obsolete. If using a newer compiler, this may be suppressed with the associated diagnostic id, otherwise, it will just show up as obsoleted APIs with the message.

Fixes #1400 