### PR TITLE
update GitVersion.yml

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,10 @@
 mode: ContinuousDeployment
 next-version: 3.0.0
-branches: {}
+branches:
+  release:
+    regex: ^release?[/-]
+    tag: beta
+    increment: None
+    is-release-branch: true
 ignore:
   sha: []


### PR DESCRIPTION
With this configuration if a prerelease release is created from a branch named `release/<release num>`, then the release will be named `<some release num>-beta<a number>` where "some release num" is the value of `next-version` in GitVersion.yml and "a number" is the number of commits since the version source.