### PR TITLE
Reduce unnecessary target builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,6 +39,7 @@
     <When Condition=" '$(ProjectLoadStyle)' == 'net35' ">
       <PropertyGroup>
         <ProductTargetFrameworks>net35</ProductTargetFrameworks>
+        <FrameworkTargetFrameworks>net35</FrameworkTargetFrameworks>
         <TestTargetFrameworks>net452</TestTargetFrameworks>
         <AssetsTargetFrameworks>net452</AssetsTargetFrameworks>
         <LatestTargetFramework>net461</LatestTargetFramework>
@@ -48,6 +49,7 @@
     <When Condition=" '$(ProjectLoadStyle)' == 'net40' ">
       <PropertyGroup>
         <ProductTargetFrameworks>net40</ProductTargetFrameworks>
+        <FrameworkTargetFrameworks>net40</FrameworkTargetFrameworks>
         <TestTargetFrameworks>net452</TestTargetFrameworks>
         <AssetsTargetFrameworks>net452</AssetsTargetFrameworks>
         <LatestTargetFramework>net461</LatestTargetFramework>
@@ -57,6 +59,7 @@
     <When Condition=" '$(ProjectLoadStyle)' == 'net46' ">
       <PropertyGroup>
         <ProductTargetFrameworks>net46</ProductTargetFrameworks>
+        <FrameworkTargetFrameworks>net46</FrameworkTargetFrameworks>
         <TestTargetFrameworks>net46</TestTargetFrameworks>
         <AssetsTargetFrameworks>net452</AssetsTargetFrameworks>
         <LatestTargetFramework>net461</LatestTargetFramework>
@@ -66,6 +69,7 @@
     <When Condition=" '$(ProjectLoadStyle)' == 'net6_0' ">
       <PropertyGroup>
         <ProductTargetFrameworks>net6.0</ProductTargetFrameworks>
+        <FrameworkTargetFrameworks>net6.0</FrameworkTargetFrameworks>
         <TestTargetFrameworks>net6.0</TestTargetFrameworks>
         <AssetsTargetFrameworks>netstandard2.0</AssetsTargetFrameworks>
         <LatestTargetFramework>net6.0</LatestTargetFramework>
@@ -75,6 +79,7 @@
     <When Condition=" '$(ProjectLoadStyle)' == 'net7_0' ">
       <PropertyGroup>
         <ProductTargetFrameworks>net7.0</ProductTargetFrameworks>
+        <FrameworkTargetFrameworks>net7.0</FrameworkTargetFrameworks>
         <TestTargetFrameworks>net7.0</TestTargetFrameworks>
         <AssetsTargetFrameworks>netstandard2.0</AssetsTargetFrameworks>
         <LatestTargetFramework>net7.0</LatestTargetFramework>
@@ -83,7 +88,8 @@
     </When>
     <When Condition=" '$(ProjectLoadStyle)' == 'All' ">
       <PropertyGroup>
-        <ProductTargetFrameworks>netstandard2.0;net6.0;net35;net40;net46</ProductTargetFrameworks>
+        <ProductTargetFrameworks>netstandard2.0;net35;net40</ProductTargetFrameworks>
+        <FrameworkTargetFrameworks>netstandard2.0;net6.0;net35;net40;net46</FrameworkTargetFrameworks>
         <AssetsTargetFrameworks>net452;netstandard2.0</AssetsTargetFrameworks>
         <TestTargetFrameworks>net452;net46;net6.0;net7.0</TestTargetFrameworks>
         <LatestTargetFramework>net7.0</LatestTargetFramework>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,6 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <IsTrimmable Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">true</IsTrimmable>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>$(ProductTargetFrameworks)</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/DocumentFormat.OpenXml.Features/DocumentFormat.OpenXml.Features.csproj
+++ b/src/DocumentFormat.OpenXml.Features/DocumentFormat.OpenXml.Features.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <IsShipped>true</IsShipped>
     <IncludeFrameworkShims>true</IncludeFrameworkShims>
+    <TargetFrameworks>$(ProductTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/DocumentFormat.OpenXml.Framework/DocumentFormat.OpenXml.Framework.csproj
+++ b/src/DocumentFormat.OpenXml.Framework/DocumentFormat.OpenXml.Framework.csproj
@@ -4,7 +4,8 @@
     <IsShipped>true</IsShipped>
     <NoWarn>$(NoWarn);3003</NoWarn>
     <IncludeFrameworkShims>true</IncludeFrameworkShims>
-    <IsNew>true</IsNew>
+    <IsNew>true</IsNew>    
+    <TargetFrameworks>$(FrameworkTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Linq.csproj
+++ b/src/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Linq.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsShipped>true</IsShipped>
+    <IsShipped>true</IsShipped>    
+    <TargetFrameworks>$(ProductTargetFrameworks)</TargetFrameworks>
     <Summary>Provides additional LINQ functionality to the Open XML SDK.</Summary>
     <Description>Provides additional LINQ functionality to the Open XML SDK to allow operations using XLINQ.</Description>
     <NoWarn>$(NoWarn);RS0041</NoWarn>

--- a/src/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
+++ b/src/DocumentFormat.OpenXml/DocumentFormat.OpenXml.csproj
@@ -6,6 +6,7 @@
 
     <!-- For now, we have internal access to the framework assembly. That should be removed, and then we'll need to turn this on. -->
     <IncludeFrameworkShims>false</IncludeFrameworkShims>
+    <TargetFrameworks>$(ProductTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This does not change any support, but only the framework library needs
to be built against so many targets. The rest are sufficient with .NET
3.5, .NET 4.0, and .NET Standard 2.0 as they mostly build on things in
the framework.
