### PR TITLE
Add feature to track calculation chain changes

### DIFF
--- a/src/DocumentFormat.OpenXml.Features/CalcChain/CalculationChainExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Features/CalcChain/CalculationChainExtensions.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Features;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using System;
+using System.Collections.Generic;
+
+namespace DocumentFormat.OpenXml;
+
+/// <summary>
+/// A collection of extension methods to add support for tracking <see cref="CalculationChain"/> changes.
+/// </summary>
+public static class CalculationChainExtensions
+{
+    /// <summary>
+    /// Adds calculation chain tracking that can be controlled via <see cref="ICalculationChainFeature"/> accessible via <see cref="SpreadsheetDocument.Features"/>.
+    /// </summary>
+    /// <param name="doc">Document to add calculation chain tracking to.</param>
+    public static void AddCalculationChainChangeTracking(this SpreadsheetDocument doc)
+    {
+        if (doc is null)
+        {
+            throw new ArgumentNullException(nameof(doc));
+        }
+
+        if (doc.Features.Get<ICalculationChainFeature>() is not null)
+        {
+            return;
+        }
+
+        var calcChain = new CalcChainFeature(doc);
+
+        doc.AddElementEventFeature();
+
+        var events = doc.Features.GetRequired<IElementEventFeature>();
+
+        events.Change += calcChain.Change;
+
+        doc.Features.Set<ICalculationChainFeature>(calcChain);
+    }
+
+    private sealed class CalcChainFeature : ICalculationChainFeature
+    {
+        private readonly SpreadsheetDocument _doc;
+
+        public CalcChainFeature(SpreadsheetDocument doc)
+        {
+            _doc = doc;
+        }
+
+        public bool IsPaused { get; set; }
+
+        IEnumerable<CalculationCell> ICalculationChainFeature.Chain
+        {
+            get
+            {
+                if (_doc.WorkbookPart is not { } workbook)
+                {
+                    yield break;
+                }
+
+                if (workbook.CalculationChainPart is not { } part)
+                {
+                    yield break;
+                }
+
+                if (part.CalculationChain is not { } chain)
+                {
+                    yield break;
+                }
+
+                foreach (var child in chain.ChildElements)
+                {
+                    if (child is CalculationCell cell)
+                    {
+                        yield return cell;
+                    }
+                }
+            }
+        }
+
+        internal void Change(FeatureEventArgs<PartElementEventArgs> args)
+        {
+            if (IsPaused)
+            {
+                return;
+            }
+
+            if (args.Type is EventType.Added or EventType.Removing &&
+                args.Argument.Element is CellType { CellReference: { HasValue: true } r, CellFormula: { } } c)
+            {
+                Handle(c, r, args.Type == EventType.Added);
+            }
+        }
+
+        private void Handle(CellType c, StringValue r, bool isAdding)
+        {
+            var worksheet = GetWorksheet(c);
+
+            if (worksheet is null)
+            {
+                return;
+            }
+
+            var chain = GetCalculationChain();
+
+            var existing = Find(chain, r);
+
+            if (!isAdding && existing is not null)
+            {
+                existing.Remove();
+            }
+            else if (isAdding && existing is null)
+            {
+                AddCalculationCell(chain, c, r);
+            }
+        }
+
+        // TODO: What else do we want to set here?
+        private static void AddCalculationCell(CalculationChain chain, CellType c, StringValue r)
+        {
+            var cell = new CalculationCell { CellReference = r };
+            chain.AddChild(cell);
+        }
+
+        private static CalculationCell? Find(CalculationChain chain, StringValue r)
+        {
+            foreach (var child in chain.ChildElements)
+            {
+                if (child is CalculationCell c && string.Equals(c.CellReference, r, StringComparison.OrdinalIgnoreCase))
+                {
+                    return c;
+                }
+            }
+
+            return null;
+        }
+
+        private static WorksheetPart? GetWorksheet(CellType c)
+        {
+            OpenXmlElement? element = c;
+
+            while (element is not null)
+            {
+                if (element is Worksheet w)
+                {
+                    return w.WorksheetPart;
+                }
+
+                element = element.Parent;
+            }
+
+            return null;
+        }
+
+        private CalculationChain GetCalculationChain()
+        {
+            var workbook = _doc.WorkbookPart ?? _doc.AddWorkbookPart();
+            var part = workbook.CalculationChainPart ?? workbook.AddNewPart<CalculationChainPart>();
+
+            return part.CalculationChain ??= new CalculationChain();
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml.Features/CalcChain/ICalculationChainFeature.cs
+++ b/src/DocumentFormat.OpenXml.Features/CalcChain/ICalculationChainFeature.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using System.Collections.Generic;
+
+namespace DocumentFormat.OpenXml.Features;
+
+/// <summary>
+/// A feature to track and update the <see cref="CalculationChainPart"/>.
+/// </summary>
+public interface ICalculationChainFeature
+{
+    /// <summary>
+    /// Gets the current <see cref="CalculationCell"/> entries registered in the <see cref="CalculationChainPart" />.
+    /// </summary>
+    public IEnumerable<CalculationCell> Chain { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the calculation chain is auto updated.
+    /// </summary>
+    bool IsPaused { get; set; }
+}

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/FeatureCollectionDebugView.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/FeatureCollectionDebugView.cs
@@ -25,7 +25,7 @@ internal sealed class FeatureCollectionDebugView
     public int Revision => _features.Revision;
 
     [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-    public FeatureItem[] Items => _features.Select(pair => new FeatureItem(pair.Key, pair.Value)).ToArray();
+    public object[] Items => _features.Select(pair => new FeatureItem(pair.Key, pair.Value)).ToArray();
 
     [DebuggerTypeProxy(typeof(FeatureItemDebugView))]
     [DebuggerDisplay("{Value.ToString(),nq}", Name = "{Type.ToString(),nq}", Type = "{Value.GetType().ToString(),nq}")]

--- a/test/DocumentFormat.OpenXml.Framework.Features.Tests/CalculationChainTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Features.Tests/CalculationChainTests.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using System.IO;
+using Xunit;
+
+namespace DocumentFormat.OpenXml.Features;
+
+public class CalculationChainTests
+{
+    [Fact]
+    public void FeatureIsAvailable()
+    {
+        // Arrange
+        using var doc = SpreadsheetDocument.Create(new MemoryStream(), SpreadsheetDocumentType.Workbook);
+
+        // Act
+        doc.AddCalculationChainChangeTracking();
+        var feature = doc.Features.Get<ICalculationChainFeature>();
+
+        // Assert
+        Assert.NotNull(feature);
+        Assert.Empty(feature.Chain);
+        Assert.False(feature.IsPaused);
+    }
+
+    [Fact]
+    public void AddsNewFormula()
+    {
+        // Arrange
+        const string CellReference = "A2";
+        const string Formula = "1+2";
+
+        using var doc = SpreadsheetDocument.Create(new MemoryStream(), SpreadsheetDocumentType.Workbook);
+
+        doc.AddCalculationChainChangeTracking();
+        var feature = doc.Features.Get<ICalculationChainFeature>();
+
+        var row = AddNewRowToDoc(doc);
+
+        // Act
+        var cell = new Cell(new CellFormula(Formula))
+        {
+            CellReference = CellReference,
+        };
+        row.AppendChild(cell);
+
+        // Assert
+        Assert.NotNull(feature);
+        Assert.Collection(
+            feature.Chain,
+            item =>
+            {
+                Assert.Equal(CellReference, item.CellReference);
+            });
+        Assert.Equal(feature.Chain, doc.WorkbookPart!.CalculationChainPart!.CalculationChain.ChildElements);
+        Assert.False(feature.IsPaused);
+    }
+
+    [Fact]
+    public void RemoveFromCalcChainWhenFormulaIsRemoved()
+    {
+        // Arrange
+        const string CellReference = "A2";
+        const string Formula = "1+2";
+
+        using var doc = SpreadsheetDocument.Create(new MemoryStream(), SpreadsheetDocumentType.Workbook);
+
+        doc.AddCalculationChainChangeTracking();
+        var feature = doc.Features.Get<ICalculationChainFeature>();
+        Assert.NotNull(feature);
+
+        var row = AddNewRowToDoc(doc);
+        var cell = new Cell(new CellFormula(Formula))
+        {
+            CellReference = CellReference,
+        };
+        row.AppendChild(cell);
+        Assert.NotEmpty(feature.Chain);
+
+        // Act
+        row.RemoveChild(cell);
+
+        // Assert
+        Assert.Empty(feature.Chain);
+        Assert.Empty(doc.WorkbookPart!.CalculationChainPart!.CalculationChain.ChildElements);
+        Assert.False(feature.IsPaused);
+    }
+
+    private static Row AddNewRowToDoc(SpreadsheetDocument doc)
+    {
+        var workbook = doc.WorkbookPart ?? doc.AddWorkbookPart();
+        var worksheetPart = workbook.AddNewPart<WorksheetPart>();
+
+        var worksheet = new Worksheet();
+        worksheetPart.Worksheet = worksheet;
+
+        var data = worksheet.AppendChild(new SheetData());
+
+        return data.AppendChild(new Row());
+    }
+}


### PR DESCRIPTION
This is an example of how we may be able to support calculation chain tracking. It does not handle all cases, nor set all values necessary for the calculation chain. It does, however, show how we can track additions or removals of formulas and react accordingly.
