### PR TITLE
Move locking out of main code

### DIFF
--- a/src/DocumentFormat.OpenXml.Framework/Builder/OpenXmlPackageBuilderExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Builder/OpenXmlPackageBuilderExtensions.cs
@@ -72,7 +72,7 @@ internal static class OpenXmlPackageBuilderExtensions
         builder.Use((package, next) =>
         {
             package.UseCloning();
-            package.Features.Set<IPackageSaveFeature>(new DefaultSaveFeature(package));
+            package.UseSaving();
             package.UseTransitionalRelationshipNamespaces();
             package.IgnoreRelationship("http://schemas.microsoft.com/office/2006/relationships/recovered");
 
@@ -110,22 +110,6 @@ internal static class OpenXmlPackageBuilderExtensions
              !settings.MarkupCompatibilityProcessSettings.TargetFileFormatVersions.Any())
         {
             throw new ArgumentException(ExceptionMessages.InvalidMCMode);
-        }
-    }
-
-    private sealed class DefaultSaveFeature : IPackageSaveFeature
-    {
-        private readonly OpenXmlPackage _package;
-
-        public DefaultSaveFeature(OpenXmlPackage package)
-        {
-            _package = package;
-        }
-
-        public void Save()
-        {
-            _package.SavePartContents(true);
-            _package.Features.GetRequired<IPackageFeature>().Package.Save();
         }
     }
 }

--- a/src/DocumentFormat.OpenXml.Framework/Builder/PackageSaveExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Builder/PackageSaveExtensions.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Features;
+using DocumentFormat.OpenXml.Packaging;
+using System.IO;
+
+namespace DocumentFormat.OpenXml.Builder;
+
+internal static class PackageSaveExtensions
+{
+    public static void UseSaving(this OpenXmlPackage package)
+    {
+        package.Features.Set<IPackageSaveFeature>(new DefaultSaveFeature(package));
+
+        if (package.AutoSave)
+        {
+            package.Features.GetRequired<IDisposableFeature>().Register(() => package.Save());
+        }
+    }
+
+    private sealed class DefaultSaveFeature : IPackageSaveFeature
+    {
+        private readonly OpenXmlPackage _package;
+
+        public DefaultSaveFeature(OpenXmlPackage package)
+        {
+            _package = package;
+        }
+
+        public bool ShouldSave => _package.Features.GetRequired<IPackageFeature>().Package.FileOpenAccess != FileAccess.Read;
+
+        public void Save()
+            => _package.Features.GetRequired<IPackageFeature>().Package.Save();
+
+        public void Save(OpenXmlPart part)
+        {
+            // Only save if the part has changed and is loaded
+            if (IsPartContentChanged(part) && part.PartRootElement is not null)
+            {
+                part.PartRootElement.Save();
+            }
+        }
+
+        private static bool IsPartContentChanged(OpenXmlPart part)
+        {
+            // If the root element of the part is loaded,
+            // consider the part changed and should be saved.
+            if (!part.IsRootElementLoaded &&
+                part.OpenXmlPackage.MarkupCompatibilityProcessSettings.ProcessMode == MarkupCompatibilityProcessMode.ProcessAllParts)
+            {
+                if (part.PartRootElement is not null)
+                {
+                    return true;
+                }
+            }
+
+            return part.IsRootElementLoaded;
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml.Framework/Features/ICloningFeature.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/ICloningFeature.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Packaging;
+
+namespace DocumentFormat.OpenXml.Features;
+
+internal interface ICloningFeature<TPackage>
+{
+    void CopyParts(TPackage destination, OpenSettings? settings = null);
+}

--- a/src/DocumentFormat.OpenXml.Framework/Features/IPackageSaveFeature.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/IPackageSaveFeature.cs
@@ -3,7 +3,7 @@
 
 namespace DocumentFormat.OpenXml.Features;
 
-internal interface ILockFeature
+internal interface IPackageSaveFeature
 {
-    object SyncLock { get; }
+    void Save();
 }

--- a/src/DocumentFormat.OpenXml.Framework/Features/IPackageSaveFeature.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/IPackageSaveFeature.cs
@@ -1,9 +1,0 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-namespace DocumentFormat.OpenXml.Features;
-
-internal interface IPackageSaveFeature
-{
-    void Save();
-}

--- a/src/DocumentFormat.OpenXml.Framework/Features/ISaveFeature.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/ISaveFeature.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using DocumentFormat.OpenXml.Packaging;
-using System;
 
 namespace DocumentFormat.OpenXml.Features;
 
-internal interface ISaveFeature
+internal interface IPackageSaveFeature
 {
-    void Save(OpenXmlPartContainer container);
+    bool ShouldSave { get; }
 
-    void Register(Action<OpenXmlPartContainer> container);
+    void Save();
+
+    void Save(OpenXmlPart part);
 }

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPackage.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPackage.cs
@@ -328,7 +328,7 @@ namespace DocumentFormat.OpenXml.Packaging
         /// </summary>
         public bool AutoSave => OpenSettings.AutoSave;
 
-        private void SavePartContents(bool save)
+        internal void SavePartContents(bool save)
         {
             if (Features.Get<IPackageFeature>() is { Package: { } package })
             {
@@ -602,11 +602,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
             if (Features.Get<IPackageFeature>() is { Package: { FileOpenAccess: FileAccess.ReadWrite } package })
             {
-                lock (Features.GetRequired<ILockFeature>().SyncLock)
-                {
-                    SavePartContents(true);
-                    package.Save();
-                }
+                Features.GetRequired<IPackageSaveFeature>().Save();
             }
         }
 

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/PackageFeatureCollection.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/PackageFeatureCollection.cs
@@ -18,8 +18,7 @@ internal partial class PackageFeatureCollection :
     IContainerDisposableFeature,
     ISaveFeature,
     IDataPartsFeature,
-    IPartsFeature,
-    ILockFeature
+    IPartsFeature
 {
     private Action<OpenXmlPartContainer>? _save;
     private Action? _disposable;
@@ -101,8 +100,6 @@ internal partial class PackageFeatureCollection :
     IEnumerable<DataPart> IDataPartsFeature.Parts => _dataParts ?? Enumerable.Empty<DataPart>();
 
     int IDataPartsFeature.Count => _dataParts?.Count ?? 0;
-
-    object ILockFeature.SyncLock { get; } = new();
 
     void IDataPartsFeature.Add(DataPart dataPart)
         => (_dataParts ??= new()).AddLast(dataPart);

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/PackageFeatureCollection.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/PackageFeatureCollection.cs
@@ -16,11 +16,9 @@ internal partial class PackageFeatureCollection :
     IApplicationTypeFeature,
     IDisposableFeature,
     IContainerDisposableFeature,
-    ISaveFeature,
     IDataPartsFeature,
     IPartsFeature
 {
-    private Action<OpenXmlPartContainer>? _save;
     private Action? _disposable;
     private LinkedList<DataPart>? _dataParts;
     private Dictionary<Uri, OpenXmlPart>? _parts;
@@ -72,12 +70,6 @@ internal partial class PackageFeatureCollection :
         _disposable?.Invoke();
         _disposable = null;
     }
-
-    void ISaveFeature.Save(OpenXmlPartContainer container)
-        => _save?.Invoke(container);
-
-    void ISaveFeature.Register(Action<OpenXmlPartContainer> container)
-        => _save += container;
 
     bool IDataPartsFeature.TryGetDataPart(Uri uri, [MaybeNullWhen(false)] out DataPart dataPart)
     {

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/PackageLockingExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/PackageLockingExtensions.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Features;
+using System;
+
+namespace DocumentFormat.OpenXml.Packaging;
+
+/// <summary>
+/// Extension methods that attempt to enable support in a few areas for multi-threaded package access
+/// </summary>
+internal static class PackageLockingExtensions
+{
+    /// <summary>
+    /// Enables a few multi-threaded package access scenarios. This is not exhaustive, but currently enables some basic
+    /// locking around the following scenarios:
+    /// <list type="bullet">
+    /// <item>Saving</item>
+    /// <item>Cloning</item>
+    /// </list>
+    /// </summary>
+    public static void UseLocking<TPackage>(this TPackage package)
+        where TPackage : OpenXmlPackage
+    {
+        if (package is null)
+        {
+            throw new ArgumentNullException(nameof(package));
+        }
+
+        var lockFeature = new LockedFeature<TPackage>(package);
+
+        package.Features.Set<IPackageSaveFeature>(lockFeature);
+        package.Features.Set<ICloningFeature<TPackage>>(lockFeature);
+    }
+
+    private sealed class LockedFeature<TPackage> : ICloningFeature<TPackage>, IPackageSaveFeature
+        where TPackage : OpenXmlPackage
+    {
+        private readonly object _syncLock = new();
+        private readonly ICloningFeature<TPackage> _clone;
+        private readonly IPackageSaveFeature _save;
+
+        public LockedFeature(TPackage package)
+        {
+            _clone = package.Features.GetRequired<ICloningFeature<TPackage>>();
+            _save = package.Features.GetRequired<IPackageSaveFeature>();
+        }
+
+        void ICloningFeature<TPackage>.CopyParts(TPackage destination, OpenSettings? settings)
+        {
+            lock (_syncLock)
+            {
+                _clone.CopyParts(destination, settings);
+            }
+        }
+
+        void IPackageSaveFeature.Save()
+        {
+            lock (_syncLock)
+            {
+                _save.Save();
+            }
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml.Framework/Packaging/PackageLockingExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/PackageLockingExtensions.cs
@@ -54,11 +54,21 @@ internal static class PackageLockingExtensions
             }
         }
 
+        bool IPackageSaveFeature.ShouldSave => _save.ShouldSave;
+
         void IPackageSaveFeature.Save()
         {
             lock (_syncLock)
             {
                 _save.Save();
+            }
+        }
+
+        void IPackageSaveFeature.Save(OpenXmlPart part)
+        {
+            lock (_syncLock)
+            {
+                _save.Save(part);
             }
         }
     }

--- a/test/DocumentFormat.OpenXml.Framework.Tests/ObjectSizeTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/ObjectSizeTests.cs
@@ -25,7 +25,7 @@ public class ObjectSizeTests
     [InlineData(typeof(TestOpenXmlElement), 64, 80, 0, 6)]
     [InlineData(typeof(TestOpenXmlElement.FeatureCollection), 24, 40, 0, 3)]
     [InlineData(typeof(TestOpenXmlPackage), 24, 40, 3, 5)]
-    [InlineData(typeof(TestOpenXmlPackage.FeatureCollection), 96, 112, 0, 11)]
+    [InlineData(typeof(TestOpenXmlPackage.FeatureCollection), 88, 104, 0, 10)]
     [InlineData(typeof(TestOpenXmlPart), 32, 48, 7, 5)]
     [InlineData(typeof(TestOpenXmlPart.FeatureCollection), 48, 64, 0, 5)]
     [InlineData(typeof(TestOpenXmlPartContainer), 8, 24, 0, 1)]


### PR DESCRIPTION
A couple of places had locking code that enabled some scenarios, but would affect all code regardless. Now, it can be opted into (but also applied by default if compat mode is set to v2).
