### PR TITLE
Push to CI feed

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,10 +30,11 @@ jobs:
       - name: Install .NET Core from global.json
         uses: actions/setup-dotnet@v3
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0
+        uses: gittools/actions/gitversion/setup@v0.9.15
         with:
-          versionSpec: '6.x'
-          includePrerelease: true
+          # v5.10.0 of GitVersion has a fix for incorrect versions when building tags. See https://github.com/GitTools/GitVersion/issues/2838
+          # It appears that the fix then had a regression in a later version, so locking in 5.10.0.  See https://github.com/GitTools/GitVersion/issues/3351#issuecomment-1403657689
+          versionSpec: '5.10.0' 
       - name: Determine Version
         uses: gittools/actions/gitversion/execute@v0
         with:
@@ -150,7 +151,29 @@ jobs:
              name: Signed
              path: |
                ${{ github.workspace }}\unsigned\*.snupkg
-               ${{ github.workspace }}\unsigned\raw\*.nupkg 
+               ${{ github.workspace }}\unsigned\raw\*.nupkg
+  CI:
+    name: "Push to CI feed"
+    needs: [sign]
+    runs-on: ubuntu-latest
+    steps:
+         - name: Install .NET Core
+           uses: actions/setup-dotnet@v3
+         - name: Download Packages
+           uses: actions/download-artifact@v3
+           with: 
+                name: Signed
+                path: '${{ github.workspace }}/packages'
+         - name: Push to CI feed
+           env:
+              SLEET_FEED_TYPE: azure
+              SLEET_FEED_CONTAINER: feed
+              SLEET_FEED_CONNECTIONSTRING: ${{secrets.SLEET_CONNECTIONSTRING}}
+           run: |
+            cd $GITHUB_WORKSPACE/packages
+            dotnet tool install -g sleet
+            sleet push . --skip-existing
+
   releaseInfo:
     name: Release Info
     runs-on: windows-latest


### PR DESCRIPTION
- Need to use 5.10.0 per
https://github.com/GitTools/GitVersion/issues/2838
- 6.x will remove NuGetSemVer2