### PR TITLE
Remove NuGet.Packaging.Core, as it's an assembly that only contains forwarders

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,6 @@
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="NuGet.Common" Version="6.9.1" />
     <PackageVersion Include="NuGet.Packaging" Version="6.9.1" />
-    <PackageVersion Include="NuGet.Packaging.Core" Version="6.9.1" />
     <PackageVersion Include="NuGet.Protocol" Version="6.9.1" />
     <PackageVersion Include="NuGet.Resolver" Version="6.8.0" />
     <PackageVersion Include="ObjectLayoutInspector" Version="0.1.4" />

--- a/test/DocumentFormat.OpenXml.Generator.Tests/DocumentFormat.OpenXml.Generator.Tests.csproj
+++ b/test/DocumentFormat.OpenXml.Generator.Tests/DocumentFormat.OpenXml.Generator.Tests.csproj
@@ -8,7 +8,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" />
     <PackageReference Include="NuGet.Common" />
     <PackageReference Include="NuGet.Packaging" />
-    <PackageReference Include="NuGet.Packaging.Core" />
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="NuGet.Resolver" />
   </ItemGroup>


### PR DESCRIPTION
Remove NuGet.Packaging.Core since it only contains type forwarders. 

![image](https://github.com/dotnet/Open-XML-SDK/assets/2878341/a09b3425-9026-4f2c-83a7-1b7d54d049ab)
