### PR TITLE
A fix to the use of <remark> tags rather than <remarks> in the documentation comments

### DIFF
--- a/gen/DocumentFormat.OpenXml.Generator.Models/Editor/DocumentCommentExtensions.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Models/Editor/DocumentCommentExtensions.cs
@@ -14,7 +14,7 @@ internal static class DocumentCommentExtensions
     public static void WriteDocumentationComment(this TextWriter writer, DocumentCommentOptions option)
     {
         AddParagraphs("summary", writer, option.Summary);
-        AddParagraphs("remark", writer, option.Remarks);
+        AddParagraphs("remarks", writer, option.Remarks);
 
         foreach (var parameter in option.Parameters)
         {

--- a/src/DocumentFormat.OpenXml/Schema/Presentation/CommentPropertiesExtension.cs
+++ b/src/DocumentFormat.OpenXml/Schema/Presentation/CommentPropertiesExtension.cs
@@ -11,13 +11,13 @@ namespace DocumentFormat.OpenXml.Office2021.PowerPoint.Comment
     /// <para>This class is available in Office 2021 and above.</para>
     /// <para>When the object is serialized out as xml, it's qualified name is p:ext.</para>
     /// </summary>
-    /// <remark>
+    /// <remarks>
     /// <para>The following table lists the possible child types:</para>
     /// <list type="bullet">
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2022.M03.Main.Reactions" /> <c>&lt;p223:reactions></c></description></item>
     ///   <item><description><see cref="DocumentFormat.OpenXml.Office.PowerPoint.Y2022.M08.Main.TaskDetails" /> <c>&lt;p228:taskDetails></c></description></item>
     /// </list>
-    /// </remark>
+    /// </remarks>
     [Obsolete("Unused type, prefer DocumentFormat.OpenXml.Presentation.CommentPropertiesExtension", true)]
     [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public partial class CommentPropertiesExtension : DocumentFormat.OpenXml.Presentation.CommentPropertiesExtension

--- a/src/DocumentFormat.OpenXml/Schema/Wordprocessing/CustomXmlElement.cs
+++ b/src/DocumentFormat.OpenXml/Schema/Wordprocessing/CustomXmlElement.cs
@@ -42,10 +42,10 @@ namespace DocumentFormat.OpenXml.Wordprocessing
         /// <summary>
         /// Gets or sets the custom XML Markup Namespace.
         /// </summary>
-        /// <remark>
+        /// <remarks>
         /// Represents the attribute in schema: w:uri.
         /// xmlns:w=http://schemas.openxmlformats.org/wordprocessingml/2006/main.
-        /// </remark>
+        /// </remarks>
         public StringValue? Uri
         {
             get => GetAttribute<StringValue>();
@@ -55,10 +55,10 @@ namespace DocumentFormat.OpenXml.Wordprocessing
         /// <summary>
         /// Gets or sets the element name.
         /// </summary>
-        /// <remark>
+        /// <remarks>
         /// Represents the attribute in schema: w:element.
         /// xmlns:w=http://schemas.openxmlformats.org/wordprocessingml/2006/main.
-        /// </remark>
+        /// </remarks>
         public StringValue? Element
         {
             get => GetAttribute<StringValue>();
@@ -68,9 +68,9 @@ namespace DocumentFormat.OpenXml.Wordprocessing
         /// <summary>
         /// Gets or sets the CustomXmlProperties which represents the element tag in schema: w:customXmlPr.
         /// </summary>
-        /// <remark>
+        /// <remarks>
         /// xmlns:w = http://schemas.openxmlformats.org/wordprocessingml/2006/main.
-        /// </remark>
+        /// </remarks>
         public CustomXmlProperties? CustomXmlProperties
         {
             get => GetElement<CustomXmlProperties>();


### PR DESCRIPTION
This PR fixes #1775
- by fixing the code generator (commit a7c4f6db5dfbcaf50d4722272afab50c8aa45430), and
- by fixing two non-generated source files (commit f0d1c08bc540428d50474df167c00de611bd245d).

The changes to the generated source files (i.e., those in `generated/`) are *not* included in this PR, because they will be re-generated by the updated code generator when building. (You will need to commit those changes to the repository by yourself...)

Note that, after applying this PR to your working tree, you *may* need to **restart Windows** and run `dotnet clean`, before running `dotnet build`.