### PR TITLE
docs: update nuget badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ The Open XML SDK provides tools for working with Office Word, Excel, and PowerPo
 
 The official release NuGet packages for Open XML SDK are on NuGet.org:
 
-| Package | Download | Prerelease |
+| Package | Stable | Prerelease |
 |---------|----------|------------|
-| DocumentFormat.OpenXml.Framework | [![NuGet](https://img.shields.io/nuget/v/DocumentFormat.OpenXml.Framework.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml.Framework) | [![NuGet](https://img.shields.io/nuget/vpre/DocumentFormat.OpenXml.Framework.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml.Framework) |
-| DocumentFormat.OpenXml | [![NuGet](https://img.shields.io/nuget/v/DocumentFormat.OpenXml.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml) | [![NuGet](https://img.shields.io/nuget/vpre/DocumentFormat.OpenXml.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml)  |
-| DocumentFormat.OpenXml.Linq | [![NuGet](https://img.shields.io/nuget/v/DocumentFormat.OpenXml.Linq.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml.Linq) | [![NuGet](https://img.shields.io/nuget/vpre/DocumentFormat.OpenXml.Linq.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml.Linq) |
-| DocumentFormat.OpenXml.Features | [![NuGet](https://img.shields.io/nuget/v/DocumentFormat.OpenXml.Features.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml.Features) | [![NuGet](https://img.shields.io/nuget/vpre/DocumentFormat.OpenXml.Features.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml.Features)  |
+| DocumentFormat.OpenXml.Framework | [![NuGet](https://img.shields.io/nuget/v/DocumentFormat.OpenXml.Framework.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml.Framework) | [![NuGet Absolute Latest](https://img.shields.io/nuget/vpre/DocumentFormat.OpenXml.Framework.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml.Framework/absoluteLatest) |
+| DocumentFormat.OpenXml | [![NuGet](https://img.shields.io/nuget/v/DocumentFormat.OpenXml.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml) | [![NuGet Absolute Latest](https://img.shields.io/nuget/vpre/DocumentFormat.OpenXml.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml/absoluteLatest)  |
+| DocumentFormat.OpenXml.Linq | [![NuGet](https://img.shields.io/nuget/v/DocumentFormat.OpenXml.Linq.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml.Linq) | [![NuGet Absolute Latest](https://img.shields.io/nuget/vpre/DocumentFormat.OpenXml.Linq.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml.Linq/absoluteLatest) |
+| DocumentFormat.OpenXml.Features | [![NuGet](https://img.shields.io/nuget/v/DocumentFormat.OpenXml.Features.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml.Features) | [![NuGet Absolute Latest](https://img.shields.io/nuget/vpre/DocumentFormat.OpenXml.Features.svg)](https://www.nuget.org/packages/DocumentFormat.OpenXml.Features/absoluteLatest)  |
 
 ## Daily Builds
 


### PR DESCRIPTION
- Update `Download` to `Stable` to compared with `Prerelease`
- Update `Prerelease` nuget package badge link to absolute latest version