### PR TITLE
Optimize ToFlatOpcString to reduce memory usage and improve performan…

### DIFF
--- a/src/DocumentFormat.OpenXml.Framework/Packaging/FlatOpcExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Packaging/FlatOpcExtensions.cs
@@ -141,25 +141,7 @@ public static class FlatOpcExtensions
     }
 
     private static string ToChunkedBase64String(byte[] byteArray)
-    {
-        // The MIME specification defines a maximum line length of 76 characters
-        // for a Base64-encoded string. Therefore, we need to break down the
-        // Base64 string into chunks of up to 76 characters each.
-        const int maxLineLength = 76;
-
-        return Convert.ToBase64String(byteArray)
-            .Select((@char, index) => new { Character = @char, Chunk = index / maxLineLength })
-            .GroupBy(charAndChunk => charAndChunk.Chunk)
-            .Aggregate(
-                new StringBuilder(),
-                (sb, grouping) => sb
-                    .Append(grouping.Aggregate(
-                        new StringBuilder(),
-                        (chunkSb, charAndChunk) => chunkSb.Append(charAndChunk.Character),
-                        chunkSb => chunkSb.ToString()))
-                    .Append(Environment.NewLine),
-                sb => sb.ToString());
-    }
+        => Convert.ToBase64String(byteArray, Base64FormattingOptions.InsertLineBreaks);
 
     internal static IPackageFactory<TPackage> WithFlatOpcTemplate<TPackage>(this IPackageFactory<TPackage> builder, string text, bool? isEditable = default)
         where TPackage : OpenXmlPackage


### PR DESCRIPTION
## Optimized the ToFlatOpcString method to address high memory usage and improve performance. 

The previous implementation relied on LINQ, which created a significant amount of intermediate collections and dictionaries, leading to inefficiency, especially when working with Word documents containing images. 

This update removes unnecessary LINQ operations and reduces memory overhead, replace manual chunking logic with Convert.ToBase64String using Base64FormattingOptions.InsertLineBreaks. 

This approach eliminates the need for LINQ-based chunking and aggregation, resulting in cleaner, more efficient code while adhering to the MIME specification for line breaks in Base64 encoding.

A sample benchmark output when working with a 822KB-word document.

![image](https://github.com/user-attachments/assets/3efadb6b-9f0f-41d5-9e8d-9992d0296469)
