### PR TITLE
add extension to CoreFilePropertiesPart to access package properties

### DIFF
--- a/src/DocumentFormat.OpenXml/Packaging/CoreFilePropertiesPart.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/CoreFilePropertiesPart.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DocumentFormat.OpenXml.Packaging
+{
+    /// <summary>
+    /// Defines the CoreFilePropertiesPart
+    /// </summary>
+    public partial class CoreFilePropertiesPart : OpenXmlPart,
+        IFixedContentTypePart
+    {
+        /// <summary>
+        /// Gets the package (core.xml) properties.
+        /// </summary>
+        public IPackageProperties CoreFileProperties => OpenXmlPackage.PackageProperties;
+    }
+}


### PR DESCRIPTION
This allows CoreFilePropertiesPart to access package properties via the parent package properties per discussion in #389 .