### PR TITLE
obsolete several child elements removed in Office 2015

### DIFF
--- a/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/DataModelWriterExtensions.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/DataModelWriterExtensions.cs
@@ -54,8 +54,8 @@ public static class DataModelWriterExtensions
             //        },
             //        {
             //              This is an example obsoleting a child attribute (property in C#)
-            //              In the json metadata: use for example "QName": ":formatCode",
-            //              ":formatCode",
+            //              In the json metadata: use for example "QName" converted to a TypedQName string: "/:formatCode",
+            //              "/:formatCode",
             //              ObsoleteAttributeWarnList
             //        },
             //  }
@@ -172,11 +172,11 @@ public static class DataModelWriterExtensions
     {
         writer.WriteDocumentationComment(BuildTypeComments(services, element));
 
-        if (_attributeData.TryGetValue(element.Name.ToString(), out Dictionary<TypedQName, List<string>> ctAttributeData))
+        if (_attributeData.TryGetValue(element.Name, out Dictionary<TypedQName, List<string>> ctAttributeData))
         {
             // if the fully qualified CT/tag name is also one of the children of the dictionary that means the attributes of that
             // child's list need to be applied to the whole class, for example, if we're obsoleting an entire class.
-            if (ctAttributeData.TryGetValue(element.Name.ToString(), out List<string> attributeStrings))
+            if (ctAttributeData.TryGetValue(element.Name, out List<string> attributeStrings))
             {
                 foreach (string attributeString in attributeStrings)
                 {
@@ -220,8 +220,8 @@ public static class DataModelWriterExtensions
             {
                 delimiter.AddDelimiter();
 
-                if (_attributeData.TryGetValue(element.Name.ToString(), out Dictionary<TypedQName, List<string>> attrAttributeData)
-                    && attrAttributeData.TryGetValue(attribute.QName.ToString(), out List<string> attrAttributeStrings))
+                if (_attributeData.TryGetValue(element.Name, out Dictionary<TypedQName, List<string>> attrAttributeData)
+                    && attrAttributeData.TryGetValue(attribute.Type + "/" + attribute.QName.ToString(), out List<string> attrAttributeStrings))
                 {
                     writer.WriteAttributeProperty(services, attribute, attrAttributeStrings);
                 }
@@ -238,8 +238,8 @@ public static class DataModelWriterExtensions
             {
                 foreach (var node in element.Children)
                 {
-                    if (_attributeData.TryGetValue(element.Name.ToString(), out Dictionary<TypedQName, List<string>> childAttributeData)
-                        && childAttributeData.TryGetValue(node.Name.ToString(), out List<string> childAttributeStrings))
+                    if (_attributeData.TryGetValue(element.Name, out Dictionary<TypedQName, List<string>> childAttributeData)
+                        && childAttributeData.TryGetValue(node.Name, out List<string> childAttributeStrings))
                     {
                         writer.WriteElement(services, element, node, ref delimiter, childAttributeStrings);
                     }

--- a/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/DataModelWriterExtensions.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/DataModelWriterExtensions.cs
@@ -29,14 +29,14 @@ public static class DataModelWriterExtensions
     ];
 
     // Use this dictionary to add attributes like ObsoleteAttribute or other directives to classes, child elements or attributes.
-    private static readonly Dictionary<string, Dictionary<string, List<string>>> _attributeData =
-        new Dictionary<string, Dictionary<string, List<string>>>()
+    private static readonly Dictionary<TypedQName, Dictionary<TypedQName, List<string>>> _attributeData =
+        new Dictionary<TypedQName, Dictionary<TypedQName, List<string>>>()
         {
             // Example with annotations:
             // {
             //  This is the containing complex type class, in the json metadata, this comes from the fully qualified "Name": "c:CT_BubbleSer/c15:ser",
             //  "c:CT_BubbleSer/c15:ser",
-            //  new Dictionary<string, List<string>>()
+            //  new Dictionary<TypedQName, List<string>>()
             //  {
             //        {
             //              This is an example of obsoleting the whole class.
@@ -62,7 +62,7 @@ public static class DataModelWriterExtensions
             // },
             {
               "c:CT_BubbleSer/c15:ser",
-              new Dictionary<string, List<string>>()
+              new Dictionary<TypedQName, List<string>>()
               {
                     {
                           "c:CT_PictureOptions/c:pictureOptions",
@@ -72,7 +72,7 @@ public static class DataModelWriterExtensions
             },
             {
               "c:CT_LineSer/c15:ser",
-              new Dictionary<string, List<string>>()
+              new Dictionary<TypedQName, List<string>>()
               {
                     {
                         "c:CT_PictureOptions/c:pictureOptions",
@@ -82,7 +82,7 @@ public static class DataModelWriterExtensions
             },
             {
                 "c:CT_PieSer/c15:ser",
-                new Dictionary<string, List<string>>()
+                new Dictionary<TypedQName, List<string>>()
                 {
                     {
                       "c:CT_PictureOptions/c:pictureOptions",
@@ -92,7 +92,7 @@ public static class DataModelWriterExtensions
             },
             {
                 "c:CT_RadarSer/c15:ser",
-                new Dictionary<string, List<string>>()
+                new Dictionary<TypedQName, List<string>>()
                 {
                     {
                       "c:CT_PictureOptions/c:pictureOptions",
@@ -102,7 +102,7 @@ public static class DataModelWriterExtensions
             },
             {
                 "c:CT_SurfaceSer/c15:ser",
-                new Dictionary<string, List<string>>()
+                new Dictionary<TypedQName, List<string>>()
                 {
                     {
                       "c:CT_PictureOptions/c:pictureOptions",
@@ -172,7 +172,7 @@ public static class DataModelWriterExtensions
     {
         writer.WriteDocumentationComment(BuildTypeComments(services, element));
 
-        if (_attributeData.TryGetValue(element.Name.ToString(), out Dictionary<string, List<string>> ctAttributeData))
+        if (_attributeData.TryGetValue(element.Name.ToString(), out Dictionary<TypedQName, List<string>> ctAttributeData))
         {
             // if the fully qualified CT/tag name is also one of the children of the dictionary that means the attributes of that
             // child's list need to be applied to the whole class, for example, if we're obsoleting an entire class.
@@ -220,7 +220,7 @@ public static class DataModelWriterExtensions
             {
                 delimiter.AddDelimiter();
 
-                if (_attributeData.TryGetValue(element.Name.ToString(), out Dictionary<string, List<string>> attrAttributeData)
+                if (_attributeData.TryGetValue(element.Name.ToString(), out Dictionary<TypedQName, List<string>> attrAttributeData)
                     && attrAttributeData.TryGetValue(attribute.QName.ToString(), out List<string> attrAttributeStrings))
                 {
                     writer.WriteAttributeProperty(services, attribute, attrAttributeStrings);
@@ -238,7 +238,7 @@ public static class DataModelWriterExtensions
             {
                 foreach (var node in element.Children)
                 {
-                    if (_attributeData.TryGetValue(element.Name.ToString(), out Dictionary<string, List<string>> childAttributeData)
+                    if (_attributeData.TryGetValue(element.Name.ToString(), out Dictionary<TypedQName, List<string>> childAttributeData)
                         && childAttributeData.TryGetValue(node.Name.ToString(), out List<string> childAttributeStrings))
                     {
                         writer.WriteElement(services, element, node, ref delimiter, childAttributeStrings);

--- a/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/DataModelWriterExtensions.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/DataModelWriterExtensions.cs
@@ -11,6 +11,17 @@ namespace DocumentFormat.OpenXml.Generator.Generators.Elements;
 
 public static class DataModelWriterExtensions
 {
+    public static class AttributeStrings
+    {
+        public const string ObsoletePropertyWarn = "[Obsolete(\"Unused property, will be removed in a future version.\", false)]";
+        public const string ObsoletePropertyError = "[Obsolete(\"Unused property, will be removed in a future version.\", true)]";
+        public const string ObsoleteAttributeWarn = "[Obsolete(\"Unused attribute, will be removed in a future version.\", false)]";
+        public const string ObsoleteAttributeError = "[Obsolete(\"Unused attribute, will be removed in a future version.\", true)]";
+        public const string EditorBrowsableAlways = "[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Always)] ";
+        public const string EditorBrowsableAdvanced = "[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Advanced)] ";
+        public const string EditorBrowsableNever = "[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] ";
+    }
+
     // Use this dictionary to add attributes like ObsoleteAttribute or other directives to classes, child elements or attributes.
     private static readonly Dictionary<string, Dictionary<string, List<string>>> _attributeData =
         new Dictionary<string, Dictionary<string, List<string>>>()
@@ -63,8 +74,8 @@ public static class DataModelWriterExtensions
                           "c:CT_PictureOptions/c:pictureOptions",
                           new List<string>()
                           {
-                          "[Obsolete(\"Unused property, will be removed in the next major version.\", false)]",
-                          "[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] ",
+                              AttributeStrings.ObsoletePropertyWarn,
+                              AttributeStrings.EditorBrowsableNever,
                           }
                     },
               }
@@ -77,8 +88,8 @@ public static class DataModelWriterExtensions
                         "c:CT_PictureOptions/c:pictureOptions",
                         new List<string>()
                         {
-                        "[Obsolete(\"Unused property, will be removed in the next major version.\", false)]",
-                        "[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] ",
+                              AttributeStrings.ObsoletePropertyWarn,
+                              AttributeStrings.EditorBrowsableNever,
                         }
                     },
               }
@@ -91,8 +102,8 @@ public static class DataModelWriterExtensions
                       "c:CT_PictureOptions/c:pictureOptions",
                       new List<string>()
                         {
-                        "[Obsolete(\"Unused property, will be removed in the next major version.\", false)]",
-                        "[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] ",
+                              AttributeStrings.ObsoletePropertyWarn,
+                              AttributeStrings.EditorBrowsableNever,
                         }
                     },
                 }
@@ -105,8 +116,8 @@ public static class DataModelWriterExtensions
                       "c:CT_PictureOptions/c:pictureOptions",
                       new List<string>()
                         {
-                        "[Obsolete(\"Unused property, will be removed in the next major version.\", false)]",
-                        "[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] ",
+                              AttributeStrings.ObsoletePropertyWarn,
+                              AttributeStrings.EditorBrowsableNever,
                         }
                     },
                 }
@@ -119,16 +130,16 @@ public static class DataModelWriterExtensions
                       "c:CT_PictureOptions/c:pictureOptions",
                       new List<string>()
                         {
-                        "[Obsolete(\"Unused property, will be removed in the next major version.\", false)]",
-                        "[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] ",
+                              AttributeStrings.ObsoletePropertyWarn,
+                              AttributeStrings.EditorBrowsableNever,
                         }
                     },
                     {
                       "c:CT_Boolean/c:bubble3D",
                       new List<string>()
                         {
-                        "[Obsolete(\"Unused property, will be removed in the next major version.\", false)]",
-                        "[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] ",
+                              AttributeStrings.ObsoletePropertyWarn,
+                              AttributeStrings.EditorBrowsableNever,
                         }
                     },
                 }

--- a/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/DataModelWriterExtensions.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/DataModelWriterExtensions.cs
@@ -22,6 +22,12 @@ public static class DataModelWriterExtensions
         public const string EditorBrowsableNever = "[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] ";
     }
 
+    private static readonly List<string> ObsoletePropertyWarnList =
+    [
+        AttributeStrings.ObsoletePropertyWarn,
+        AttributeStrings.EditorBrowsableNever,
+    ];
+
     // Use this dictionary to add attributes like ObsoleteAttribute or other directives to classes, child elements or attributes.
     private static readonly Dictionary<string, Dictionary<string, List<string>>> _attributeData =
         new Dictionary<string, Dictionary<string, List<string>>>()
@@ -37,32 +43,20 @@ public static class DataModelWriterExtensions
             //              In the json metadata:
             //                    Use the same fully qualified name as the class, for example "Name": "c:CT_BubbleSer/c15:ser",
             //              "c:CT_BubbleSer/c15:ser",
-            //              new List<string>()
-            //              {
-            //              "[Obsolete(\"Unused property, will be removed in the next major version.\", false)]",
-            //              "[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] ",
-            //              }
+            //              ObsoleteClassErrorList
             //        },
             //        {
             //              This is an example obsoleting a child element (property in C#)
             //              In the json metadata:
             //                    For child elements, this comes from "Name": "c:CT_PictureOptions/c:pictureOptions",
             //              "c:CT_PictureOptions/c:pictureOptions",
-            //              new List<string>()
-            //              {
-            //              "[Obsolete(\"Unused property, will be removed in the next major version.\", false)]",
-            //              "[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] ",
-            //              }
+            //              ObsoletePropertyWarnList
             //        },
             //        {
             //              This is an example obsoleting a child attribute (property in C#)
             //              In the json metadata: use for example "QName": ":formatCode",
             //              ":formatCode",
-            //              new List<string>()
-            //              {
-            //              "[Obsolete(\"Unused property, will be removed in the next major version.\", false)]",
-            //              "[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] ",
-            //              }
+            //              ObsoleteAttributeWarnList
             //        },
             //  }
             // },
@@ -72,11 +66,7 @@ public static class DataModelWriterExtensions
               {
                     {
                           "c:CT_PictureOptions/c:pictureOptions",
-                          new List<string>()
-                          {
-                              AttributeStrings.ObsoletePropertyWarn,
-                              AttributeStrings.EditorBrowsableNever,
-                          }
+                          ObsoletePropertyWarnList
                     },
               }
             },
@@ -86,11 +76,7 @@ public static class DataModelWriterExtensions
               {
                     {
                         "c:CT_PictureOptions/c:pictureOptions",
-                        new List<string>()
-                        {
-                              AttributeStrings.ObsoletePropertyWarn,
-                              AttributeStrings.EditorBrowsableNever,
-                        }
+                        ObsoletePropertyWarnList
                     },
               }
             },
@@ -100,11 +86,7 @@ public static class DataModelWriterExtensions
                 {
                     {
                       "c:CT_PictureOptions/c:pictureOptions",
-                      new List<string>()
-                        {
-                              AttributeStrings.ObsoletePropertyWarn,
-                              AttributeStrings.EditorBrowsableNever,
-                        }
+                      ObsoletePropertyWarnList
                     },
                 }
             },
@@ -114,11 +96,7 @@ public static class DataModelWriterExtensions
                 {
                     {
                       "c:CT_PictureOptions/c:pictureOptions",
-                      new List<string>()
-                        {
-                              AttributeStrings.ObsoletePropertyWarn,
-                              AttributeStrings.EditorBrowsableNever,
-                        }
+                      ObsoletePropertyWarnList
                     },
                 }
             },
@@ -128,25 +106,15 @@ public static class DataModelWriterExtensions
                 {
                     {
                       "c:CT_PictureOptions/c:pictureOptions",
-                      new List<string>()
-                        {
-                              AttributeStrings.ObsoletePropertyWarn,
-                              AttributeStrings.EditorBrowsableNever,
-                        }
+                      ObsoletePropertyWarnList
                     },
                     {
                       "c:CT_Boolean/c:bubble3D",
-                      new List<string>()
-                        {
-                              AttributeStrings.ObsoletePropertyWarn,
-                              AttributeStrings.EditorBrowsableNever,
-                        }
+                      ObsoletePropertyWarnList
                     },
                 }
             },
         };
-
-    private static string _elementAttributeStrings = string.Empty;
 
     public static bool GetDataModelSyntax(this IndentedTextWriter writer, OpenXmlGeneratorServices services, SchemaNamespace model)
     {

--- a/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/DataModelWriterExtensions.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/DataModelWriterExtensions.cs
@@ -54,8 +54,9 @@ public static class DataModelWriterExtensions
             //        },
             //        {
             //              This is an example obsoleting a child attribute (property in C#)
-            //              In the json metadata: use for example "QName" converted to a TypedQName string: "/:formatCode",
-            //              "/:formatCode",
+            //              In the json metadata: use for example "QName" converted to a TypedQName string using the C# type from the
+            //              Type property with no prefix: ":StringValue/:formatCode",
+            //              ":StringValue/:formatCode",
             //              ObsoleteAttributeWarnList
             //        },
             //  }
@@ -221,7 +222,7 @@ public static class DataModelWriterExtensions
                 delimiter.AddDelimiter();
 
                 if (_attributeData.TryGetValue(element.Name, out Dictionary<TypedQName, List<string>> attrAttributeData)
-                    && attrAttributeData.TryGetValue(attribute.Type + "/" + attribute.QName.ToString(), out List<string> attrAttributeStrings))
+                    && attrAttributeData.TryGetValue(":" + attribute.Type + "/" + attribute.QName.ToString(), out List<string> attrAttributeStrings))
                 {
                     writer.WriteAttributeProperty(services, attribute, attrAttributeStrings);
                 }

--- a/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/DataModelWriterExtensions.cs
+++ b/gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/DataModelWriterExtensions.cs
@@ -18,7 +18,7 @@ public static class DataModelWriterExtensions
             // Example with annotations:
             // {
             //  This is the containing complex type class, in the json metadata, this comes from the fully qualified "Name": "c:CT_BubbleSer/c15:ser",
-            //  "c:CT_BubbleSer/c15:ser", 
+            //  "c:CT_BubbleSer/c15:ser",
             //  new Dictionary<string, List<string>>()
             //  {
             //        {
@@ -195,8 +195,8 @@ public static class DataModelWriterExtensions
 
         if (_attributeData.TryGetValue(element.Name.ToString(), out Dictionary<string, List<string>> ctAttributeData))
         {
-            // if the fully qualified CT/tag name is also one of the children of the dictionary that means the attributes of that 
-            // child's list need to be applied to the whole class, for example, if we're obsoleting an entire class. 
+            // if the fully qualified CT/tag name is also one of the children of the dictionary that means the attributes of that
+            // child's list need to be applied to the whole class, for example, if we're obsoleting an entire class.
             if (ctAttributeData.TryGetValue(element.Name.ToString(), out List<string> attributeStrings))
             {
                 foreach (string attributeString in attributeStrings)

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2012_chart.g.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2012_chart.g.cs
@@ -2542,6 +2542,8 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.Chart
         /// <remarks>
         /// xmlns:c = http://schemas.openxmlformats.org/drawingml/2006/chart
         /// </remarks>
+        [Obsolete("Unused property, will be removed in the next major version.", false)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
         public DocumentFormat.OpenXml.Drawing.Charts.PictureOptions? PictureOptions
         {
             get => GetElement<DocumentFormat.OpenXml.Drawing.Charts.PictureOptions>();
@@ -3034,6 +3036,8 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.Chart
         /// <remarks>
         /// xmlns:c = http://schemas.openxmlformats.org/drawingml/2006/chart
         /// </remarks>
+        [Obsolete("Unused property, will be removed in the next major version.", false)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
         public DocumentFormat.OpenXml.Drawing.Charts.PictureOptions? PictureOptions
         {
             get => GetElement<DocumentFormat.OpenXml.Drawing.Charts.PictureOptions>();
@@ -3220,6 +3224,8 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.Chart
         /// <remarks>
         /// xmlns:c = http://schemas.openxmlformats.org/drawingml/2006/chart
         /// </remarks>
+        [Obsolete("Unused property, will be removed in the next major version.", false)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
         public DocumentFormat.OpenXml.Drawing.Charts.PictureOptions? PictureOptions
         {
             get => GetElement<DocumentFormat.OpenXml.Drawing.Charts.PictureOptions>();
@@ -3394,6 +3400,8 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.Chart
         /// <remarks>
         /// xmlns:c = http://schemas.openxmlformats.org/drawingml/2006/chart
         /// </remarks>
+        [Obsolete("Unused property, will be removed in the next major version.", false)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
         public DocumentFormat.OpenXml.Drawing.Charts.PictureOptions? PictureOptions
         {
             get => GetElement<DocumentFormat.OpenXml.Drawing.Charts.PictureOptions>();
@@ -3562,6 +3570,8 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.Chart
         /// <remarks>
         /// xmlns:c = http://schemas.openxmlformats.org/drawingml/2006/chart
         /// </remarks>
+        [Obsolete("Unused property, will be removed in the next major version.", false)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
         public DocumentFormat.OpenXml.Drawing.Charts.PictureOptions? PictureOptions
         {
             get => GetElement<DocumentFormat.OpenXml.Drawing.Charts.PictureOptions>();
@@ -3601,6 +3611,8 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.Chart
         /// <remarks>
         /// xmlns:c = http://schemas.openxmlformats.org/drawingml/2006/chart
         /// </remarks>
+        [Obsolete("Unused property, will be removed in the next major version.", false)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
         public DocumentFormat.OpenXml.Drawing.Charts.Bubble3D? Bubble3D
         {
             get => GetElement<DocumentFormat.OpenXml.Drawing.Charts.Bubble3D>();

--- a/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2012_chart.g.cs
+++ b/generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2012_chart.g.cs
@@ -2542,7 +2542,7 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.Chart
         /// <remarks>
         /// xmlns:c = http://schemas.openxmlformats.org/drawingml/2006/chart
         /// </remarks>
-        [Obsolete("Unused property, will be removed in the next major version.", false)]
+        [Obsolete("Unused property, will be removed in a future version.", false)]
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
         public DocumentFormat.OpenXml.Drawing.Charts.PictureOptions? PictureOptions
         {
@@ -3036,7 +3036,7 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.Chart
         /// <remarks>
         /// xmlns:c = http://schemas.openxmlformats.org/drawingml/2006/chart
         /// </remarks>
-        [Obsolete("Unused property, will be removed in the next major version.", false)]
+        [Obsolete("Unused property, will be removed in a future version.", false)]
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
         public DocumentFormat.OpenXml.Drawing.Charts.PictureOptions? PictureOptions
         {
@@ -3224,7 +3224,7 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.Chart
         /// <remarks>
         /// xmlns:c = http://schemas.openxmlformats.org/drawingml/2006/chart
         /// </remarks>
-        [Obsolete("Unused property, will be removed in the next major version.", false)]
+        [Obsolete("Unused property, will be removed in a future version.", false)]
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
         public DocumentFormat.OpenXml.Drawing.Charts.PictureOptions? PictureOptions
         {
@@ -3400,7 +3400,7 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.Chart
         /// <remarks>
         /// xmlns:c = http://schemas.openxmlformats.org/drawingml/2006/chart
         /// </remarks>
-        [Obsolete("Unused property, will be removed in the next major version.", false)]
+        [Obsolete("Unused property, will be removed in a future version.", false)]
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
         public DocumentFormat.OpenXml.Drawing.Charts.PictureOptions? PictureOptions
         {
@@ -3570,7 +3570,7 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.Chart
         /// <remarks>
         /// xmlns:c = http://schemas.openxmlformats.org/drawingml/2006/chart
         /// </remarks>
-        [Obsolete("Unused property, will be removed in the next major version.", false)]
+        [Obsolete("Unused property, will be removed in a future version.", false)]
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
         public DocumentFormat.OpenXml.Drawing.Charts.PictureOptions? PictureOptions
         {
@@ -3611,7 +3611,7 @@ namespace DocumentFormat.OpenXml.Office2013.Drawing.Chart
         /// <remarks>
         /// xmlns:c = http://schemas.openxmlformats.org/drawingml/2006/chart
         /// </remarks>
-        [Obsolete("Unused property, will be removed in the next major version.", false)]
+        [Obsolete("Unused property, will be removed in a future version.", false)]
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
         public DocumentFormat.OpenXml.Drawing.Charts.Bubble3D? Bubble3D
         {


### PR DESCRIPTION
this pr obsoletes the properties mentioned in #1769 
it also adds code to the generator to add code attributes like ObsoleteAttribute to complex type classes, child elements and attributes.