### PR TITLE
Add IsMinimumDocument method to WordprocessingDocument, SpreadsheetDocument, and PresentationDocument

### DIFF
--- a/src/DocumentFormat.OpenXml/Packaging/PresentationDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/PresentationDocument.cs
@@ -274,11 +274,35 @@ namespace DocumentFormat.OpenXml.Packaging
         /// Validates whether the specified file is a minimum valid PresentationDocument.
         /// </summary>
         /// <param name="path">The path to the PresentationDocument file.</param>
-        /// <param name="documentType">The expected type of the PresentationDocument. Defaults to PresentationDocumentType.Presentation.</param>
-        /// <returns>True if the file is a minimum valid PresentationDocument; otherwise, false.</returns>
+        /// <param name="documentType">
+        /// The expected type of the PresentationDocument. Defaults to <see cref="PresentationDocumentType.Presentation"/>.
+        /// Supported types are:
+        /// <list type="bullet">
+        /// <item><see cref="PresentationDocumentType.Presentation"/> (.pptx)</item>
+        /// <item><see cref="PresentationDocumentType.Template"/> (.potx)</item>
+        /// <item><see cref="PresentationDocumentType.MacroEnabledPresentation"/> (.pptm)</item>
+        /// <item><see cref="PresentationDocumentType.MacroEnabledTemplate"/> (.potm)</item>
+        /// </list>
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if the file is a minimum valid PresentationDocument; otherwise, <c>false</c>.
+        /// </returns>
         /// <exception cref="ArgumentException">
         /// Thrown when the <paramref name="documentType"/> is invalid or unsupported.
         /// </exception>
+        /// <remarks>
+        /// A minimum valid PresentationDocument must meet the following criteria:
+        /// <list type="bullet">
+        /// <item>The file must exist and have a valid extension matching the <paramref name="documentType"/>.</item>
+        /// <item>The file must contain a valid <see cref="NotesSize"/> element in the presentation part.</item>
+        /// </list>
+        /// Unsupported document types include:
+        /// <list type="bullet">
+        /// <item><see cref="PresentationDocumentType.AddIn"/> (.ppam)</item>
+        /// <item><see cref="PresentationDocumentType.Slideshow"/> (.ppsx)</item>
+        /// <item><see cref="PresentationDocumentType.MacroEnabledSlideshow"/> (.ppsm)</item>
+        /// </list>
+        /// </remarks>
         public static bool IsMinimumDocument(string path, PresentationDocumentType documentType = PresentationDocumentType.Presentation)
         {
             if (documentType == PresentationDocumentType.AddIn || documentType == PresentationDocumentType.Slideshow || documentType == PresentationDocumentType.MacroEnabledSlideshow)

--- a/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.cs
@@ -269,14 +269,47 @@ namespace DocumentFormat.OpenXml.Packaging
             => Open(package, new OpenSettings());
 
         /// <summary>
-        /// Validates whether the specified file is a valid SpreadsheetDocument of the given type.
+        /// Validates whether the specified file is a minimum valid SpreadsheetDocument.
         /// </summary>
         /// <param name="path">The path to the SpreadsheetDocument file.</param>
-        /// <param name="documentType">The expected type of the SpreadsheetDocument. Defaults to <see cref="SpreadsheetDocumentType.Workbook"/>.</param>
-        /// <returns>True if the file is a valid SpreadsheetDocument of the specified type; otherwise, false.</returns>
-        public static bool IsValidDocument(string path, SpreadsheetDocumentType documentType = SpreadsheetDocumentType.Workbook)
+        /// <param name="documentType">
+        /// The expected type of the SpreadsheetDocument. Defaults to <see cref="SpreadsheetDocumentType.Workbook"/>.
+        /// Supported types are:
+        /// <list type="bullet">
+        /// <item><see cref="SpreadsheetDocumentType.Workbook"/> (.xlsx)</item>
+        /// <item><see cref="SpreadsheetDocumentType.Template"/> (.xltx)</item>
+        /// <item><see cref="SpreadsheetDocumentType.MacroEnabledWorkbook"/> (.xlsm)</item>
+        /// <item><see cref="SpreadsheetDocumentType.MacroEnabledTemplate"/> (.xltm)</item>
+        /// </list>
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if the file is a minimum valid SpreadsheetDocument; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the <paramref name="documentType"/> is invalid or unsupported.
+        /// </exception>
+        /// <remarks>
+        /// A minimum valid SpreadsheetDocument must meet the following criteria:
+        /// <list type="bullet">
+        /// <item>The file must exist and have a valid extension matching the <paramref name="documentType"/>.</item>
+        /// <item>The file must contain at least one <see cref="Sheet"/> element in the workbook part.</item>
+        /// <item>The file must contain at least one <see cref="SheetData"/> element in the worksheet part.</item>
+        /// </list>
+        /// Unsupported document types include <see cref="SpreadsheetDocumentType.AddIn"/> (.xlam).
+        /// </remarks>
+        public static bool IsMinimumDocument(string path, SpreadsheetDocumentType documentType = SpreadsheetDocumentType.Workbook)
         {
+            if (documentType == SpreadsheetDocumentType.AddIn)
+            {
+                throw new ArgumentException($"Invalid value: {documentType}. Allowed values are SpreadsheetDocumentType.Workbook, SpreadsheetDocumentType.Template, SpreadsheetDocumentType.MacroEnabledWorkbook, and SpreadsheetDocumentType.MacroEnabledTemplate.");
+            }
+
             if (string.IsNullOrEmpty(path))
+            {
+                return false;
+            }
+
+            if (path.IndexOfAny(System.IO.Path.GetInvalidPathChars()) >= 0)
             {
                 return false;
             }
@@ -321,12 +354,7 @@ namespace DocumentFormat.OpenXml.Packaging
 
                         break;
                     case ".XLAM":
-                        if (documentType != SpreadsheetDocumentType.AddIn)
-                        {
-                            return false;
-                        }
-
-                        break;
+                        throw new FileFormatException($"Validation for SpreadsheetDocument.AddIn (.xlam) is not supported.");
                     default:
                         return false;
                 }

--- a/src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.cs
@@ -311,14 +311,37 @@ namespace DocumentFormat.OpenXml.Packaging
             => Open(package, new OpenSettings());
 
         /// <summary>
-        /// Validates whether the specified file is a valid WordprocessingDocument of the given type.
+        /// Validates whether the specified file is a minimum valid WordprocessingDocument.
         /// </summary>
         /// <param name="path">The path to the WordprocessingDocument file.</param>
-        /// <param name="documentType">The expected type of the WordprocessingDocument. Defaults to <see cref="WordprocessingDocumentType.Document"/>.</param>
-        /// <returns>True if the file is a valid WordprocessingDocument of the specified type; otherwise, false.</returns>
-        public static bool IsValidDocument(string path, WordprocessingDocumentType documentType = WordprocessingDocumentType.Document)
+        /// <param name="documentType">
+        /// The expected type of the WordprocessingDocument. Defaults to <see cref="WordprocessingDocumentType.Document"/>.
+        /// Supported types are:
+        /// <list type="bullet">
+        /// <item><see cref="WordprocessingDocumentType.Document"/> (.docx)</item>
+        /// <item><see cref="WordprocessingDocumentType.Template"/> (.dotx)</item>
+        /// <item><see cref="WordprocessingDocumentType.MacroEnabledDocument"/> (.docm)</item>
+        /// <item><see cref="WordprocessingDocumentType.MacroEnabledTemplate"/> (.dotm)</item>
+        /// </list>
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if the file is a minimum valid WordprocessingDocument; otherwise, <c>false</c>.
+        /// </returns>
+        /// <remarks>
+        /// A minimum valid WordprocessingDocument must meet the following criteria:
+        /// <list type="bullet">
+        /// <item>The file must exist and have a valid extension matching the <paramref name="documentType"/>.</item>
+        /// <item>The file must contain a <see cref="Body"/> element in the main document part.</item>
+        /// </list>
+        /// </remarks>
+        public static bool IsMinimumDocument(string path, WordprocessingDocumentType documentType = WordprocessingDocumentType.Document)
         {
             if (string.IsNullOrEmpty(path))
+            {
+                return false;
+            }
+
+            if (path.IndexOfAny(System.IO.Path.GetInvalidPathChars()) >= 0)
             {
                 return false;
             }

--- a/src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.cs
+++ b/src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.cs
@@ -311,6 +311,73 @@ namespace DocumentFormat.OpenXml.Packaging
             => Open(package, new OpenSettings());
 
         /// <summary>
+        /// Validates whether the specified file is a valid WordprocessingDocument of the given type.
+        /// </summary>
+        /// <param name="path">The path to the WordprocessingDocument file.</param>
+        /// <param name="documentType">The expected type of the WordprocessingDocument. Defaults to <see cref="WordprocessingDocumentType.Document"/>.</param>
+        /// <returns>True if the file is a valid WordprocessingDocument of the specified type; otherwise, false.</returns>
+        public static bool IsValidDocument(string path, WordprocessingDocumentType documentType = WordprocessingDocumentType.Document)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return false;
+            }
+
+            try
+            {
+                if (!File.Exists(path))
+                {
+                    return false;
+                }
+
+                string ext = new FileInfo(path).Extension.ToUpperInvariant();
+
+                switch (ext)
+                {
+                    case ".DOCX":
+                        if (documentType != WordprocessingDocumentType.Document)
+                        {
+                            return false;
+                        }
+
+                        break;
+                    case ".DOTX":
+                        if (documentType != WordprocessingDocumentType.Template)
+                        {
+                            return false;
+                        }
+
+                        break;
+                    case ".DOCM":
+                        if (documentType != WordprocessingDocumentType.MacroEnabledDocument)
+                        {
+                            return false;
+                        }
+
+                        break;
+                    case ".DOTM":
+                        if (documentType != WordprocessingDocumentType.MacroEnabledTemplate)
+                        {
+                            return false;
+                        }
+
+                        break;
+                    default:
+                        return false;
+                }
+
+                using (WordprocessingDocument wordprocessingDocument = Open(path, false))
+                {
+                    return wordprocessingDocument?.MainDocumentPart?.Document?.Body is not null;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Changes the document type.
         /// </summary>
         /// <param name="newType">The new type of the document.</param>

--- a/test/DocumentFormat.OpenXml.Packaging.Tests/OpenXmlPackageTests.cs
+++ b/test/DocumentFormat.OpenXml.Packaging.Tests/OpenXmlPackageTests.cs
@@ -331,197 +331,141 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
             Assert.NotNull(spd);
         }
 
+        #region WordprocessingDocument.IsMinimumDocument tests
         [Fact]
-        public void WordprocessingDocument_IsValidDocument_ShouldReturnFalse_WhenPathIsNull()
+        public void WordprocessingDocument_IsMinimumDocument_ValidDocx_ReturnsTrue()
         {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), "valid.docx");
+
+            using (var wordDocument = WordprocessingDocument.Create(filePath, WordprocessingDocumentType.Document))
+            {
+                var mainPart = wordDocument.AddMainDocumentPart();
+                mainPart.Document = new Document(new Body());
+            }
+
             // Act
-            bool result = WordprocessingDocument.IsValidDocument(null);
+            bool result = WordprocessingDocument.IsMinimumDocument(filePath, WordprocessingDocumentType.Document);
+
+            // Assert
+            Assert.True(result);
+
+            // Cleanup
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void WordprocessingDocument_IsMinimumDocument_ValidDotx_ReturnsTrue()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), "valid.dotx");
+
+            using (var wordDocument = WordprocessingDocument.Create(filePath, WordprocessingDocumentType.Document))
+            {
+                var mainPart = wordDocument.AddMainDocumentPart();
+                mainPart.Document = new Document(new Body());
+            }
+
+            // Act
+            bool result = WordprocessingDocument.IsMinimumDocument(filePath, WordprocessingDocumentType.Template);
+
+            // Assert
+            Assert.True(result);
+
+            // Cleanup
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void WordprocessingDocument_IsMinimumDocument_InvalidExtension_ReturnsFalse()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), "invalid-ext.txt");
+
+            File.WriteAllText(filePath, string.Empty);
+
+            // Act
+            bool result = WordprocessingDocument.IsMinimumDocument(filePath, WordprocessingDocumentType.Document);
+
+            // Assert
+            Assert.False(result);
+
+            // Cleanup
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void WordprocessingDocument_IsMinimumDocument_NonExistentFile_ReturnsFalse()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), "nonexistent.docx");
+
+            // Act
+            bool result = WordprocessingDocument.IsMinimumDocument(filePath, WordprocessingDocumentType.Document);
 
             // Assert
             Assert.False(result);
         }
 
         [Fact]
-        public void WordprocessingDocument_IsValidDocument_ShouldReturnFalse_WhenFileDoesNotExist()
+        public void WordprocessingDocument_IsMinimumDocument_InvalidPathCharacters_ReturnsFalse()
         {
             // Arrange
-            string nonExistentPath = string.Concat(Path.GetTempPath(), "nonexistent.docx");
+            string filePath = "invalid|path.docx";
 
             // Act
-            bool result = WordprocessingDocument.IsValidDocument(nonExistentPath);
+            bool result = WordprocessingDocument.IsMinimumDocument(filePath, WordprocessingDocumentType.Document);
 
             // Assert
             Assert.False(result);
         }
 
         [Fact]
-        public void WordprocessingDocument_IsValidDocument_ShouldReturnFalse_WhenFileExtensionIsUnsupported()
-        {
-            // Arrange
-            string unsupportedFilePath = string.Concat(Path.GetTempPath(), "unsupported.txt");
-            File.WriteAllText(unsupportedFilePath, "Test content");
-
-            try
-            {
-                // Act
-                bool result = WordprocessingDocument.IsValidDocument(unsupportedFilePath);
-
-                // Assert
-                Assert.False(result);
-            }
-            finally
-            {
-                File.Delete(unsupportedFilePath);
-            }
-        }
-
-        [Fact]
-        public void WordprocessingDocument_IsValidDocument_ShouldReturnFalse_WhenDocumentTypeDoesNotMatchExtension()
-        {
-            // Arrange
-            string filePath = string.Concat(Path.GetTempPath(), "test.docx");
-            File.WriteAllText(filePath, "Test content");
-
-            try
-            {
-                // Act
-                bool result = WordprocessingDocument.IsValidDocument(filePath, WordprocessingDocumentType.Template);
-
-                // Assert
-                Assert.False(result);
-            }
-            finally
-            {
-                File.Delete(filePath);
-            }
-        }
-
-        [Fact]
-        public void WordprocessingDocument_IsValidDocument_ShouldReturnTrue_ForValidDocument()
-        {
-            // Arrange
-            string filePath = string.Concat(Path.GetTempPath(), "test.docx");
-
-            using (WordprocessingDocument document = WordprocessingDocument.Create(filePath, WordprocessingDocumentType.Document))
-            {
-                document.AddMainDocumentPart();
-                document.MainDocumentPart.Document = new Document(new Body());
-            }
-
-            try
-            {
-                // Act
-                bool result = WordprocessingDocument.IsValidDocument(filePath);
-
-                // Assert
-                Assert.True(result);
-            }
-            finally
-            {
-                File.Delete(filePath);
-            }
-        }
-
-        [Fact]
-        public void WordprocessingDocument_IsValidDocument_ShouldReturnFalse_WhenDocumentIsCorrupted()
-        {
-            // Arrange
-            string corruptedFilePath = string.Concat(Path.GetTempPath(), "corrupt.docx");
-            using (WordprocessingDocument wordprocessingDocument = WordprocessingDocument.Create(corruptedFilePath, WordprocessingDocumentType.Document))
-            {
-                MainDocumentPart mainDocumentPart = wordprocessingDocument.AddMainDocumentPart();
-
-                mainDocumentPart.Document = new Document(new Paragraph());
-            }
-
-            try
-            {
-                // Act
-                bool result = WordprocessingDocument.IsValidDocument(corruptedFilePath);
-
-                // Assert
-                Assert.False(result);
-            }
-            finally
-            {
-                File.Delete(corruptedFilePath);
-            }
-        }
-
-        [Fact]
-        public void SpreadsheetDocument_IsValidDocument_ShouldReturnFalse_WhenPathIsNull()
+        public void WordprocessingDocument_IsMinimumDocument_EmptyPath_ReturnsFalse()
         {
             // Act
-            bool result = SpreadsheetDocument.IsValidDocument(null);
+            bool result = WordprocessingDocument.IsMinimumDocument(string.Empty, WordprocessingDocumentType.Document);
 
             // Assert
             Assert.False(result);
         }
 
         [Fact]
-        public void SpreadsheetDocument_IsValidDocument_ShouldReturnFalse_WhenFileDoesNotExist()
+        public void WordprocessingDocument_IsMinimumDocument_NullPath_ReturnsFalse()
         {
-            // Arrange
-            string nonExistentPath = string.Concat(Path.GetTempPath(), "nonexistent.docx");
-
             // Act
-            bool result = SpreadsheetDocument.IsValidDocument(nonExistentPath);
+            bool result = WordprocessingDocument.IsMinimumDocument(null, WordprocessingDocumentType.Document);
 
             // Assert
             Assert.False(result);
         }
 
         [Fact]
-        public void SpreadsheetDocument_IsValidDocument_ShouldReturnFalse_WhenFileExtensionIsUnsupported()
+        public void WordprocessingDocument_IsMinimumDocument_InvalidContent_ReturnsFalse()
         {
             // Arrange
-            string unsupportedFilePath = Path.GetTempFileName();
-            File.WriteAllText(unsupportedFilePath, "Test content");
+            string filePath = Path.Combine(Path.GetTempPath(), "invalid.docx");
 
-            try
+            using (var wordDocument = WordprocessingDocument.Create(filePath, WordprocessingDocumentType.Document))
             {
-                // Act
-                bool result = SpreadsheetDocument.IsValidDocument(unsupportedFilePath);
+                var mainPart = wordDocument.AddMainDocumentPart();
+                mainPart.Document = new Document();
+            }
 
-                // Assert
-                Assert.False(result);
-            }
-            finally
-            {
-                File.Delete(unsupportedFilePath);
-            }
+            // Act
+            bool result = WordprocessingDocument.IsMinimumDocument(filePath, WordprocessingDocumentType.Document);
+
+            // Assert
+            Assert.False(result);
+
+            // Cleanup
+            File.Delete(filePath);
         }
+        #endregion
 
+        #region SpreadsheetDocument.IsMinimumDocument tests
         [Fact]
-        public void SpreadsheetDocument_IsValidDocument_ShouldReturnFalse_WhenDocumentTypeDoesNotMatchExtension()
-        {
-            // Arrange
-            string filePath = Path.Combine(Path.GetTempPath(), "test.xlsx");
-
-            using (SpreadsheetDocument spreadsheetDocument = SpreadsheetDocument.Create(filePath, SpreadsheetDocumentType.Workbook))
-            {
-                WorkbookPart wbp = spreadsheetDocument.AddWorkbookPart();
-                WorksheetPart wsp = wbp.AddNewPart<WorksheetPart>();
-                wbp.Workbook = new Spreadsheet.Workbook(new Spreadsheet.Sheets(new Spreadsheet.Sheet() { Id = wbp.GetIdOfPart(wsp), SheetId = 1, Name = "Sheet1" }));
-                wsp.Worksheet = new Spreadsheet.Worksheet(new Spreadsheet.SheetData());
-            }
-
-            try
-            {
-                // Act
-                bool result = SpreadsheetDocument.IsValidDocument(filePath, SpreadsheetDocumentType.Template);
-
-                // Assert
-                Assert.False(result);
-            }
-            finally
-            {
-                File.Delete(filePath);
-            }
-        }
-
-        [Fact]
-        public void SpreadsheetDocument_IsValidDocument_ShouldReturnTrue_ForValidDocument()
+        public void IsMinimumDocument_ValidXlsx_ReturnsTrue()
         {
             // Arrange
             string filePath = Path.Combine(Path.GetTempPath(), "valid.xlsx");
@@ -534,52 +478,155 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
                 wsp.Worksheet = new Spreadsheet.Worksheet(new Spreadsheet.SheetData());
             }
 
-            try
-            {
-                // Act
-                bool result = SpreadsheetDocument.IsValidDocument(filePath);
+            // Act
+            bool result = SpreadsheetDocument.IsMinimumDocument(filePath, SpreadsheetDocumentType.Workbook);
 
-                // Assert
-                Assert.True(result);
-            }
-            finally
-            {
-                File.Delete(filePath);
-            }
+            // Assert
+            Assert.True(result);
+
+            // Cleanup
+            File.Delete(filePath);
         }
 
         [Fact]
-        public void SpreadsheetDocument_IsValidDocument_ShouldReturnFalse_WhenDocumentIsInvalid()
+        public void IsMinimumDocument_ValidXltx_ReturnsTrue()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), "valid.xltx");
+
+            using (SpreadsheetDocument spreadsheetDocument = SpreadsheetDocument.Create(filePath, SpreadsheetDocumentType.Template))
+            {
+                WorkbookPart wbp = spreadsheetDocument.AddWorkbookPart();
+                WorksheetPart wsp = wbp.AddNewPart<WorksheetPart>();
+                wbp.Workbook = new Spreadsheet.Workbook(new Spreadsheet.Sheets(new Spreadsheet.Sheet() { Id = wbp.GetIdOfPart(wsp), SheetId = 1, Name = "Sheet1" }));
+                wsp.Worksheet = new Spreadsheet.Worksheet(new Spreadsheet.SheetData());
+            }
+
+            // Act
+            bool result = SpreadsheetDocument.IsMinimumDocument(filePath, SpreadsheetDocumentType.Template);
+
+            // Assert
+            Assert.True(result);
+
+            // Cleanup
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void SpreadsheetDocument_IsMinimumDocument_InvalidExtension_ReturnsFalse()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), string.Concat(Path.GetTempFileName(), ".txt"));
+            File.WriteAllText(filePath, string.Empty);
+
+            // Act
+            bool result = SpreadsheetDocument.IsMinimumDocument(filePath, SpreadsheetDocumentType.Workbook);
+
+            // Assert
+            Assert.False(result);
+
+            // Cleanup
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void SpreadsheetDocument_IsMinimumDocument_NonExistentFile_ReturnsFalse()
+        {
+            // Arrange
+            string filePath = "nonexistent.xlsx";
+
+            // Act
+            bool result = SpreadsheetDocument.IsMinimumDocument(filePath, SpreadsheetDocumentType.Workbook);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void SpreadsheetDocument_IsMinimumDocument_InvalidPathCharacters_ReturnsFalse()
+        {
+            // Arrange
+            string filePath = "invalid|path.xlsx";
+
+            // Act
+            bool result = SpreadsheetDocument.IsMinimumDocument(filePath, SpreadsheetDocumentType.Workbook);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void SpreadsheetDocument_IsMinimumDocument_UnsupportedDocumentType_ThrowsArgumentException()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), "valid.xlsx");
+
+            using (SpreadsheetDocument spreadsheetDocument = SpreadsheetDocument.Create(filePath, SpreadsheetDocumentType.Workbook))
+            {
+                WorkbookPart wbp = spreadsheetDocument.AddWorkbookPart();
+                WorksheetPart wsp = wbp.AddNewPart<WorksheetPart>();
+                wbp.Workbook = new Spreadsheet.Workbook(new Spreadsheet.Sheets(new Spreadsheet.Sheet() { Id = wbp.GetIdOfPart(wsp), SheetId = 1, Name = "Sheet1" }));
+                wsp.Worksheet = new Spreadsheet.Worksheet(new Spreadsheet.SheetData());
+            }
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() =>
+                SpreadsheetDocument.IsMinimumDocument(filePath, SpreadsheetDocumentType.AddIn));
+
+            // Cleanup
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void SpreadsheetDocument_IsMinimumDocument_EmptyPath_ReturnsFalse()
+        {
+            // Act
+            bool result = SpreadsheetDocument.IsMinimumDocument(string.Empty, SpreadsheetDocumentType.Workbook);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void SpreadsheetDocument_IsMinimumDocument_NullPath_ReturnsFalse()
+        {
+            // Act
+            bool result = SpreadsheetDocument.IsMinimumDocument(null, SpreadsheetDocumentType.Workbook);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void SpreadsheetDocument_IsMinimumDocument_InvalidContent_ReturnsFalse()
         {
             // Arrange
             string filePath = Path.Combine(Path.GetTempPath(), "invalid.xlsx");
 
-            using (SpreadsheetDocument invalidSpreadsheetDocument = SpreadsheetDocument.Create(filePath, SpreadsheetDocumentType.Workbook))
+            using (SpreadsheetDocument spreadsheetDocument = SpreadsheetDocument.Create(filePath, SpreadsheetDocumentType.Workbook))
             {
-                WorkbookPart wbp = invalidSpreadsheetDocument.AddWorkbookPart();
+                WorkbookPart wbp = spreadsheetDocument.AddWorkbookPart();
                 WorksheetPart wsp = wbp.AddNewPart<WorksheetPart>();
+                wbp.Workbook = new Spreadsheet.Workbook(new Spreadsheet.Sheets(new Spreadsheet.Sheet() { Id = wbp.GetIdOfPart(wsp), SheetId = 1, Name = "Sheet1" }));
             }
 
-            try
-            {
-                // Act
-                bool result = SpreadsheetDocument.IsValidDocument(filePath);
+            // Act
+            bool result = SpreadsheetDocument.IsMinimumDocument(filePath, SpreadsheetDocumentType.Workbook);
 
-                // Assert
-                Assert.False(result);
-            }
-            finally
-            {
-                File.Delete(filePath);
-            }
+            // Assert
+            Assert.False(result);
+
+            // Cleanup
+            File.Delete(filePath);
         }
+        #endregion
 
-#region PresentationDocument.IsMinimumDocument tests
+        #region PresentationDocument.IsMinimumDocument tests
         [Fact]
         public void IsMinimumDocument_ValidPptx_ReturnsTrue()
         {
             // Arrange
-            string filePath = Path.Combine(Path.GetTempPath(), "invalid.pptx");
+            string filePath = Path.Combine(Path.GetTempPath(), "valid.pptx");
 
             using (PresentationDocument presentationDocument = PresentationDocument.Create(filePath, PresentationDocumentType.Presentation))
             {
@@ -622,7 +669,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         }
 
         [Fact]
-        public void IsMinimumDocument_InvalidExtension_ReturnsFalse()
+        public void PresentationDocument_IsMinimumDocument_InvalidExtension_ReturnsFalse()
         {
             // Arrange
             string filePath = Path.Combine(Path.GetTempPath(), "invalid.txt");
@@ -640,7 +687,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         }
 
         [Fact]
-        public void IsMinimumDocument_NonExistentFile_ReturnsFalse()
+        public void PresentationDocument_IsMinimumDocument_NonExistentFile_ReturnsFalse()
         {
             // Arrange
             string filePath = "nonexistent.pptx";
@@ -653,7 +700,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         }
 
         [Fact]
-        public void IsMinimumDocument_InvalidPathCharacters_ReturnsFalse()
+        public void PresentationDocument_IsMinimumDocument_InvalidPathCharacters_ReturnsFalse()
         {
             // Arrange
             string filePath = "invalid|path.pptx";
@@ -666,7 +713,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         }
 
         [Fact]
-        public void IsMinimumDocument_UnsupportedDocumentType_ThrowsArgumentException()
+        public void PresentationDocument_IsMinimumDocument_UnsupportedDocumentType_ThrowsArgumentException()
         {
             // Arrange
             string filePath = Path.Combine(Path.GetTempPath(), "invalid.pptx");
@@ -687,7 +734,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         }
 
         [Fact]
-        public void IsMinimumDocument_EmptyPath_ReturnsFalse()
+        public void PresentationDocument_IsMinimumDocument_EmptyPath_ReturnsFalse()
         {
             // Act
             bool result = PresentationDocument.IsMinimumDocument(string.Empty, PresentationDocumentType.Presentation);
@@ -697,7 +744,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         }
 
         [Fact]
-        public void IsMinimumDocument_NullPath_ReturnsFalse()
+        public void PresentationDocument_IsMinimumDocument_NullPath_ReturnsFalse()
         {
             // Act
             bool result = PresentationDocument.IsMinimumDocument(null, PresentationDocumentType.Presentation);
@@ -707,7 +754,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         }
 
         [Fact]
-        public void IsMinimumDocument_InvalidContent_ReturnsFalse()
+        public void PresentationDocument_IsMinimumDocument_InvalidContent_ReturnsFalse()
         {
             // Arrange
             string filePath = Path.Combine(Path.GetTempPath(), "invalid.pptx");

--- a/test/DocumentFormat.OpenXml.Packaging.Tests/OpenXmlPackageTests.cs
+++ b/test/DocumentFormat.OpenXml.Packaging.Tests/OpenXmlPackageTests.cs
@@ -3,7 +3,6 @@
 
 using DocumentFormat.OpenXml.Presentation;
 using DocumentFormat.OpenXml.Wordprocessing;
-using Microsoft.Testing.Platform.MSBuild;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -333,7 +332,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         }
 
         [Fact]
-        public void IsValidDocument_ShouldReturnFalse_WhenPathIsNull()
+        public void WordprocessingDocument_IsValidDocument_ShouldReturnFalse_WhenPathIsNull()
         {
             // Act
             bool result = WordprocessingDocument.IsValidDocument(null);
@@ -343,7 +342,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         }
 
         [Fact]
-        public void IsValidDocument_ShouldReturnFalse_WhenFileDoesNotExist()
+        public void WordprocessingDocument_IsValidDocument_ShouldReturnFalse_WhenFileDoesNotExist()
         {
             // Arrange
             string nonExistentPath = string.Concat(Path.GetTempPath(), "nonexistent.docx");
@@ -356,7 +355,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         }
 
         [Fact]
-        public void IsValidDocument_ShouldReturnFalse_WhenFileExtensionIsUnsupported()
+        public void WordprocessingDocument_IsValidDocument_ShouldReturnFalse_WhenFileExtensionIsUnsupported()
         {
             // Arrange
             string unsupportedFilePath = string.Concat(Path.GetTempPath(), "unsupported.txt");
@@ -377,7 +376,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         }
 
         [Fact]
-        public void IsValidDocument_ShouldReturnFalse_WhenDocumentTypeDoesNotMatchExtension()
+        public void WordprocessingDocument_IsValidDocument_ShouldReturnFalse_WhenDocumentTypeDoesNotMatchExtension()
         {
             // Arrange
             string filePath = string.Concat(Path.GetTempPath(), "test.docx");
@@ -398,7 +397,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         }
 
         [Fact]
-        public void IsValidDocument_ShouldReturnTrue_ForValidDocument()
+        public void WordprocessingDocument_IsValidDocument_ShouldReturnTrue_ForValidDocument()
         {
             // Arrange
             string filePath = string.Concat(Path.GetTempPath(), "test.docx");
@@ -424,7 +423,7 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
         }
 
         [Fact]
-        public void IsValidDocument_ShouldReturnFalse_WhenDocumentIsCorrupted()
+        public void WordprocessingDocument_IsValidDocument_ShouldReturnFalse_WhenDocumentIsCorrupted()
         {
             // Arrange
             string corruptedFilePath = string.Concat(Path.GetTempPath(), "corrupt.docx");
@@ -446,6 +445,132 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
             finally
             {
                 File.Delete(corruptedFilePath);
+            }
+        }
+
+        [Fact]
+        public void SpreadsheetDocument_IsValidDocument_ShouldReturnFalse_WhenPathIsNull()
+        {
+            // Act
+            bool result = SpreadsheetDocument.IsValidDocument(null);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void SpreadsheetDocument_IsValidDocument_ShouldReturnFalse_WhenFileDoesNotExist()
+        {
+            // Arrange
+            string nonExistentPath = string.Concat(Path.GetTempPath(), "nonexistent.docx");
+
+            // Act
+            bool result = SpreadsheetDocument.IsValidDocument(nonExistentPath);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void SpreadsheetDocument_IsValidDocument_ShouldReturnFalse_WhenFileExtensionIsUnsupported()
+        {
+            // Arrange
+            string unsupportedFilePath = Path.GetTempFileName();
+            File.WriteAllText(unsupportedFilePath, "Test content");
+
+            try
+            {
+                // Act
+                bool result = SpreadsheetDocument.IsValidDocument(unsupportedFilePath);
+
+                // Assert
+                Assert.False(result);
+            }
+            finally
+            {
+                File.Delete(unsupportedFilePath);
+            }
+        }
+
+        [Fact]
+        public void SpreadsheetDocument_IsValidDocument_ShouldReturnFalse_WhenDocumentTypeDoesNotMatchExtension()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), "test.xlsx");
+
+            using (SpreadsheetDocument spreadsheetDocument = SpreadsheetDocument.Create(filePath, SpreadsheetDocumentType.Workbook))
+            {
+                WorkbookPart wbp = spreadsheetDocument.AddWorkbookPart();
+                WorksheetPart wsp = wbp.AddNewPart<WorksheetPart>();
+                wbp.Workbook = new Spreadsheet.Workbook(new Spreadsheet.Sheets(new Spreadsheet.Sheet() { Id = wbp.GetIdOfPart(wsp), SheetId = 1, Name = "Sheet1" }));
+                wsp.Worksheet = new Spreadsheet.Worksheet(new Spreadsheet.SheetData());
+            }
+
+            try
+            {
+                // Act
+                bool result = SpreadsheetDocument.IsValidDocument(filePath, SpreadsheetDocumentType.Template);
+
+                // Assert
+                Assert.False(result);
+            }
+            finally
+            {
+                File.Delete(filePath);
+            }
+        }
+
+        [Fact]
+        public void SpreadsheetDocument_IsValidDocument_ShouldReturnTrue_ForValidDocument()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), "valid.xlsx");
+
+            using (SpreadsheetDocument spreadsheetDocument = SpreadsheetDocument.Create(filePath, SpreadsheetDocumentType.Workbook))
+            {
+                WorkbookPart wbp = spreadsheetDocument.AddWorkbookPart();
+                WorksheetPart wsp = wbp.AddNewPart<WorksheetPart>();
+                wbp.Workbook = new Spreadsheet.Workbook(new Spreadsheet.Sheets(new Spreadsheet.Sheet() { Id = wbp.GetIdOfPart(wsp), SheetId = 1, Name = "Sheet1" }));
+                wsp.Worksheet = new Spreadsheet.Worksheet(new Spreadsheet.SheetData());
+            }
+
+            try
+            {
+                // Act
+                bool result = SpreadsheetDocument.IsValidDocument(filePath);
+
+                // Assert
+                Assert.True(result);
+            }
+            finally
+            {
+                File.Delete(filePath);
+            }
+        }
+
+        [Fact]
+        public void SpreadsheetDocument_IsValidDocument_ShouldReturnFalse_WhenDocumentIsInvalid()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), "invalid.xlsx");
+
+            using (SpreadsheetDocument invalidSpreadsheetDocument = SpreadsheetDocument.Create(filePath, SpreadsheetDocumentType.Workbook))
+            {
+                WorkbookPart wbp = invalidSpreadsheetDocument.AddWorkbookPart();
+                WorksheetPart wsp = wbp.AddNewPart<WorksheetPart>();
+            }
+
+            try
+            {
+                // Act
+                bool result = SpreadsheetDocument.IsValidDocument(filePath);
+
+                // Assert
+                Assert.False(result);
+            }
+            finally
+            {
+                File.Delete(filePath);
             }
         }
     }

--- a/test/DocumentFormat.OpenXml.Packaging.Tests/OpenXmlPackageTests.cs
+++ b/test/DocumentFormat.OpenXml.Packaging.Tests/OpenXmlPackageTests.cs
@@ -573,5 +573,160 @@ namespace DocumentFormat.OpenXml.Packaging.Tests
                 File.Delete(filePath);
             }
         }
+
+#region PresentationDocument.IsMinimumDocument tests
+        [Fact]
+        public void IsMinimumDocument_ValidPptx_ReturnsTrue()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), "invalid.pptx");
+
+            using (PresentationDocument presentationDocument = PresentationDocument.Create(filePath, PresentationDocumentType.Presentation))
+            {
+                PresentationPart presentationPart = presentationDocument.AddPresentationPart();
+                presentationPart.Presentation = new Presentation.Presentation();
+                presentationPart.Presentation.AddChild(new NotesSize() { Cx = 913607, Cy = 913607 });
+            }
+
+            // Act
+            bool result = PresentationDocument.IsMinimumDocument(filePath, PresentationDocumentType.Presentation);
+
+            // Assert
+            Assert.True(result);
+
+            // Cleanup
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void IsMinimumDocument_ValidPotx_ReturnsTrue()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), "invalid.potx");
+
+            using (PresentationDocument presentationDocument = PresentationDocument.Create(filePath, PresentationDocumentType.Presentation))
+            {
+                PresentationPart presentationPart = presentationDocument.AddPresentationPart();
+                presentationPart.Presentation = new Presentation.Presentation();
+                presentationPart.Presentation.AddChild(new NotesSize() { Cx = 913607, Cy = 913607 });
+            }
+
+            // Act
+            bool result = PresentationDocument.IsMinimumDocument(filePath, PresentationDocumentType.Template);
+
+            // Assert
+            Assert.True(result);
+
+            // Cleanup
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void IsMinimumDocument_InvalidExtension_ReturnsFalse()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), "invalid.txt");
+
+            File.WriteAllText(filePath, string.Empty);
+
+            // Act
+            bool result = PresentationDocument.IsMinimumDocument(filePath, PresentationDocumentType.Presentation);
+
+            // Assert
+            Assert.False(result);
+
+            // Cleanup
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void IsMinimumDocument_NonExistentFile_ReturnsFalse()
+        {
+            // Arrange
+            string filePath = "nonexistent.pptx";
+
+            // Act
+            bool result = PresentationDocument.IsMinimumDocument(filePath, PresentationDocumentType.Presentation);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsMinimumDocument_InvalidPathCharacters_ReturnsFalse()
+        {
+            // Arrange
+            string filePath = "invalid|path.pptx";
+
+            // Act
+            bool result = PresentationDocument.IsMinimumDocument(filePath, PresentationDocumentType.Presentation);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsMinimumDocument_UnsupportedDocumentType_ThrowsArgumentException()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), "invalid.pptx");
+
+            using (PresentationDocument presentationDocument = PresentationDocument.Create(filePath, PresentationDocumentType.Presentation))
+            {
+                PresentationPart presentationPart = presentationDocument.AddPresentationPart();
+                presentationPart.Presentation = new Presentation.Presentation();
+                presentationPart.Presentation.AddChild(new NotesSize() { Cx = 913607, Cy = 913607 });
+            }
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() =>
+                PresentationDocument.IsMinimumDocument(filePath, PresentationDocumentType.AddIn));
+
+            // Cleanup
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void IsMinimumDocument_EmptyPath_ReturnsFalse()
+        {
+            // Act
+            bool result = PresentationDocument.IsMinimumDocument(string.Empty, PresentationDocumentType.Presentation);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsMinimumDocument_NullPath_ReturnsFalse()
+        {
+            // Act
+            bool result = PresentationDocument.IsMinimumDocument(null, PresentationDocumentType.Presentation);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsMinimumDocument_InvalidContent_ReturnsFalse()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), "invalid.pptx");
+
+            using (PresentationDocument presentationDocument = PresentationDocument.Create(filePath, PresentationDocumentType.Presentation))
+            {
+                PresentationPart presentationPart = presentationDocument.AddPresentationPart();
+                presentationPart.Presentation = new Presentation.Presentation();
+            }
+
+            // Act
+            bool result = PresentationDocument.IsMinimumDocument(filePath, PresentationDocumentType.Presentation);
+
+            // Assert
+            Assert.False(result);
+
+            // Cleanup
+            File.Delete(filePath);
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
- Adds methods to determine if a document is a minimum document for WordprocessingDocument, SpreadsheetDocument, and PresentationDocument.
- closes #816 