### PR TITLE
Add IOpenXmlNamespacePrefixFeature to control written namespace prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `IOpenXmlNamespacePrefixFeature` so the namespace prefixes used when saving a DOM tree can be overridden per package. Registering `OpenXmlNamespacePrefix.DefaultFor(...)` writes a namespace as the default (unprefixed) namespace, matching what Office produces, instead of the built-in prefix such as `x:` for SpreadsheetML. Saved output and `OpenXmlElement.Prefix` are both unchanged when no feature is registered.
+
 ## [3.4.1] - 2026-01-06
 
 ### Added

--- a/src/DocumentFormat.OpenXml.Framework/Features/IOpenXmlNamespacePrefixFeature.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/IOpenXmlNamespacePrefixFeature.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DocumentFormat.OpenXml.Features;
+
+/// <summary>
+/// A feature that overrides the namespace prefixes used when Open XML elements are written.
+/// </summary>
+/// <remarks>
+/// <para>
+/// By default, elements are written with a built-in prefix for their namespace, for example
+/// <c>x</c> for SpreadsheetML, so a worksheet is serialized as
+/// <c>&lt;x:worksheet xmlns:x="..."&gt;</c>. This is valid, but Office writes the part's own
+/// namespace as the default namespace instead, as <c>&lt;worksheet xmlns="..."&gt;</c>.
+/// Consumers that parse the XML without a namespace manager can be sensitive to the difference.
+/// </para>
+/// <para>
+/// Register an implementation on <see cref="Packaging.OpenXmlPackage.Features"/> to choose the
+/// prefixes instead. When no implementation is registered, the built-in prefixes are used and
+/// output is unchanged.
+/// </para>
+/// <para>
+/// This applies when a part's root element is written - <see cref="OpenXmlPartRootElement.Save()"/>
+/// and <see cref="OpenXmlPartRootElement.WriteTo(System.Xml.XmlWriter)"/> - and covers everything
+/// below it, unknown and extension elements included. It does not affect
+/// <see cref="OpenXmlElement.Prefix"/>, which continues to report the built-in prefix so that
+/// validation XPaths stay well formed; writing a non-root element directly through
+/// <see cref="OpenXmlElement.WriteTo(System.Xml.XmlWriter)"/>; or <see cref="OpenXmlPartWriter"/>,
+/// which writes prefixes supplied by its caller.
+/// </para>
+/// <para>
+/// Three limits are worth knowing before relying on this. A part root whose content was supplied as
+/// raw XML and never parsed is written verbatim, so the override does not reach it - the alternative,
+/// forcing a parse, would turn a byte-for-byte copy into a re-serialization that can fail on content
+/// the SDK is able to copy but not re-read. <see cref="OpenXmlElement.OuterXml"/> on a part root does
+/// go through the override, so it disagrees with a detached clone of the same element;
+/// <see cref="OpenXmlElement.InnerXml"/> does not, because it serializes the children directly.
+/// And a part written through the LINQ-to-XML feature - <c>GetXElement</c> and its save path - keeps
+/// the built-in prefixes, and reports them or the overridden ones depending on whether the typed
+/// root had already been materialized.
+/// </para>
+/// <para>
+/// A namespace-qualified attribute needs a prefix, so when the elements around it no longer carry
+/// one the writer declares the built-in prefix on each element that has such an attribute. This is
+/// invisible in SpreadsheetML, whose attributes are unqualified, but WordprocessingML uses them
+/// heavily - <c>w:rsidR</c>, <c>w:val</c>. Calling
+/// <see cref="OpenXmlElement.AddNamespaceDeclaration(string, string)"/> on the part root to declare
+/// the prefix once keeps those declarations off the individual elements.
+/// </para>
+/// <para>
+/// A namespace declaration already present on an element is preserved even when it binds a prefix
+/// to an overridden namespace, so a round-tripped document keeps whatever it declared. This is
+/// deliberate: element names come from the override regardless, a qualified attribute still needs a
+/// prefix to resolve against, and removing the declaration would strand any <c>mc:Ignorable</c>
+/// value naming it.
+/// </para>
+/// <para>
+/// A prefix that another Open XML namespace already owns - <c>r</c>, <c>mc</c>, <c>a</c> and the
+/// rest of the built-in table - is rejected with an <see cref="System.InvalidOperationException"/> naming
+/// both namespaces. Taking one has no good outcome: where the other namespace is declared on the
+/// same element the writer refuses it, and where it is declared further out the writer silently
+/// rebinds that namespace to a generated prefix, so <c>r:id</c> would ship as <c>p3:id</c> with no
+/// error at all. Choose a prefix outside that set, or the empty string for the default namespace.
+/// The returned prefix must also be a valid XML name; the underlying
+/// <see cref="System.Xml.XmlWriter"/> enforces that while saving.
+/// </para>
+/// <para>
+/// Note that a save which throws has already truncated the part, so the package is left incomplete.
+/// That is a property of the save path rather than of this feature, but it is worth knowing when
+/// experimenting with a resolver against a file you care about.
+/// </para>
+/// </remarks>
+/// <example>
+/// The following writes SpreadsheetML as the default namespace for a whole package:
+/// <code>
+/// using var document = SpreadsheetDocument.Create(path, SpreadsheetDocumentType.Workbook);
+///
+/// document.Features.SetNamespacePrefixOverride(
+///     OpenXmlNamespacePrefix.DefaultFor("http://schemas.openxmlformats.org/spreadsheetml/2006/main"));
+/// </code>
+/// </example>
+public interface IOpenXmlNamespacePrefixFeature
+{
+    /// <summary>
+    /// Attempts to get the prefix used to write elements that belong to <paramref name="namespaceUri"/>.
+    /// </summary>
+    /// <param name="namespaceUri">The namespace being written.</param>
+    /// <param name="prefix">
+    /// When this method returns <see langword="true"/>, the prefix to use.
+    /// <see cref="string.Empty"/> writes <paramref name="namespaceUri"/> as the default
+    /// (unprefixed) namespace.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if this feature supplies a prefix for <paramref name="namespaceUri"/>;
+    /// otherwise <see langword="false"/> to fall back to the built-in prefix.
+    /// </returns>
+    bool TryGetPrefix(string namespaceUri, out string prefix);
+}

--- a/src/DocumentFormat.OpenXml.Framework/Features/IOpenXmlNamespacePrefixFeature.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/IOpenXmlNamespacePrefixFeature.cs
@@ -55,19 +55,20 @@ namespace DocumentFormat.OpenXml.Features;
 /// value naming it.
 /// </para>
 /// <para>
-/// A prefix that another Open XML namespace already owns - <c>r</c>, <c>mc</c>, <c>a</c> and the
-/// rest of the built-in table - is rejected with an <see cref="System.InvalidOperationException"/> naming
-/// both namespaces. Taking one has no good outcome: where the other namespace is declared on the
-/// same element the writer refuses it, and where it is declared further out the writer silently
-/// rebinds that namespace to a generated prefix, so <c>r:id</c> would ship as <c>p3:id</c> with no
-/// error at all. Choose a prefix outside that set, or the empty string for the default namespace.
-/// The returned prefix must also be a valid XML name; the underlying
-/// <see cref="System.Xml.XmlWriter"/> enforces that while saving.
+/// A prefix that is already bound to another namespace - by the built-in table (<c>r</c>, <c>mc</c>,
+/// <c>a</c> and the rest) or by a declaration anywhere in the document being saved - is rejected
+/// with an <see cref="System.InvalidOperationException"/> naming both namespaces. Taking one has no
+/// good outcome: where the other namespace is declared on the same element the writer refuses it,
+/// and where it is declared further out the writer silently rebinds that namespace to a generated
+/// prefix, so <c>r:id</c> would ship as <c>p3:id</c> with no error at all. Choose a prefix outside
+/// that set, or the empty string for the default namespace. The returned prefix must also be a
+/// valid XML name, or an <see cref="System.Xml.XmlException"/> is thrown.
 /// </para>
 /// <para>
-/// Note that a save which throws has already truncated the part, so the package is left incomplete.
-/// That is a property of the save path rather than of this feature, but it is worth knowing when
-/// experimenting with a resolver against a file you care about.
+/// Every namespace the part uses is checked before the part is opened for writing, so a rejected
+/// prefix leaves the part's previous content in place. When the save runs from
+/// <see cref="Packaging.OpenXmlPackage.Dispose()"/>, the exception still surfaces there and any
+/// parts not yet saved are skipped.
 /// </para>
 /// </remarks>
 /// <example>

--- a/src/DocumentFormat.OpenXml.Framework/Features/NamespacePrefixFeatureExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/NamespacePrefixFeatureExtensions.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace DocumentFormat.OpenXml.Features;
+
+/// <summary>
+/// Extension methods for registering an <see cref="IOpenXmlNamespacePrefixFeature"/>.
+/// </summary>
+public static class NamespacePrefixFeatureExtensions
+{
+    /// <summary>
+    /// Registers a feature that controls the namespace prefixes used when elements are written.
+    /// </summary>
+    /// <param name="features">
+    /// The feature collection to register on. This must be a writable collection such as
+    /// <see cref="Packaging.OpenXmlPackage.Features"/>; an element's feature collection is read-only.
+    /// </param>
+    /// <param name="feature">The feature to register.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="features"/> or <paramref name="feature"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException"><paramref name="features"/> is read-only.</exception>
+    public static void SetNamespacePrefixOverride(this IFeatureCollection features, IOpenXmlNamespacePrefixFeature feature)
+    {
+        if (features is null)
+        {
+            throw new ArgumentNullException(nameof(features));
+        }
+
+        if (feature is null)
+        {
+            throw new ArgumentNullException(nameof(feature));
+        }
+
+        if (features.IsReadOnly)
+        {
+            throw new InvalidOperationException(ExceptionMessages.ReadOnlyFeatureCollection);
+        }
+
+        features.Set(feature);
+    }
+
+    /// <summary>
+    /// Registers a callback that controls the namespace prefixes used when elements are written.
+    /// </summary>
+    /// <param name="features">The feature collection, usually a package's.</param>
+    /// <param name="resolver">
+    /// Returns the prefix for a namespace, <see cref="string.Empty"/> to write it as the default
+    /// namespace, or <see langword="null"/> to use the built-in prefix.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="features"/> or <paramref name="resolver"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException"><paramref name="features"/> is read-only.</exception>
+    public static void SetNamespacePrefixOverride(this IFeatureCollection features, Func<string, string?> resolver)
+    {
+        // Checked before building the feature so a null collection is reported as such, rather than
+        // surfacing as a complaint about the resolver.
+        if (features is null)
+        {
+            throw new ArgumentNullException(nameof(features));
+        }
+
+        features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.Create(resolver));
+    }
+}

--- a/src/DocumentFormat.OpenXml.Framework/Features/NamespacePrefixFeatureExtensions.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/NamespacePrefixFeatureExtensions.cs
@@ -19,7 +19,6 @@ public static class NamespacePrefixFeatureExtensions
     /// </param>
     /// <param name="feature">The feature to register.</param>
     /// <exception cref="ArgumentNullException"><paramref name="features"/> or <paramref name="feature"/> is <see langword="null"/>.</exception>
-    /// <exception cref="InvalidOperationException"><paramref name="features"/> is read-only.</exception>
     public static void SetNamespacePrefixOverride(this IFeatureCollection features, IOpenXmlNamespacePrefixFeature feature)
     {
         if (features is null)
@@ -30,11 +29,6 @@ public static class NamespacePrefixFeatureExtensions
         if (feature is null)
         {
             throw new ArgumentNullException(nameof(feature));
-        }
-
-        if (features.IsReadOnly)
-        {
-            throw new InvalidOperationException(ExceptionMessages.ReadOnlyFeatureCollection);
         }
 
         features.Set(feature);
@@ -49,7 +43,6 @@ public static class NamespacePrefixFeatureExtensions
     /// namespace, or <see langword="null"/> to use the built-in prefix.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="features"/> or <paramref name="resolver"/> is <see langword="null"/>.</exception>
-    /// <exception cref="InvalidOperationException"><paramref name="features"/> is read-only.</exception>
     public static void SetNamespacePrefixOverride(this IFeatureCollection features, Func<string, string?> resolver)
     {
         // Checked before building the feature so a null collection is reported as such, rather than

--- a/src/DocumentFormat.OpenXml.Framework/Features/NamespacePrefixOverride.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/NamespacePrefixOverride.cs
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Xml;
+
+namespace DocumentFormat.OpenXml.Features;
+
+/// <summary>
+/// The prefix decisions for one save of a part: asks the registered
+/// <see cref="IOpenXmlNamespacePrefixFeature"/> and checks each answer against the prefixes that
+/// are already taken, by the built-in table or by a declaration somewhere in the tree.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Taking a prefix that is bound to another namespace has no good outcome. Where the other
+/// namespace is declared on the same element the writer rejects it outright ("the prefix cannot be
+/// redefined"); where it is declared further out the writer silently rebinds that namespace to a
+/// generated prefix, so <c>r:id</c> ships as <c>p3:id</c> with no error at all. Callers cannot be
+/// expected to know which prefixes a loaded document uses, so this is reported here rather than
+/// left to the writer.
+/// </para>
+/// <para>
+/// <see cref="Create"/> walks the tree once and checks every namespace it uses up front, so that a
+/// prefix the feature cannot be given is reported before the part is opened for writing - opening
+/// truncates it. Each answer is checked again as elements are written, because nothing in the
+/// contract requires a feature to answer the same prefix for a namespace every time.
+/// </para>
+/// </remarks>
+internal sealed class NamespacePrefixOverride
+{
+    private readonly IOpenXmlNamespacePrefixFeature _feature;
+    private readonly IOpenXmlNamespaceResolver _resolver;
+
+    // Prefixes the tree declares itself, keyed by prefix.
+    private readonly Dictionary<string, string> _declared;
+
+    // The prefix already checked for each namespace. Keyed by namespace and compared by prefix, so
+    // that a changed answer is checked afresh rather than waved through.
+    private readonly Dictionary<string, string> _validated = new(StringComparer.Ordinal);
+
+    private NamespacePrefixOverride(IOpenXmlNamespacePrefixFeature feature, IOpenXmlNamespaceResolver resolver, Dictionary<string, string> declared)
+    {
+        _feature = feature;
+        _resolver = resolver;
+        _declared = declared;
+    }
+
+    /// <summary>
+    /// Gets the namespace resolver of the part being saved.
+    /// </summary>
+    public IOpenXmlNamespaceResolver Resolver => _resolver;
+
+    /// <summary>
+    /// Gets the namespace declarations found in the tree, keyed by prefix. Where a prefix is declared
+    /// more than once the declaration nearest the root wins.
+    /// </summary>
+    /// <remarks>
+    /// Collected while checking prefixes, and exposed so that the root does not walk the tree a
+    /// second time to hoist declarations onto itself.
+    /// </remarks>
+    public Dictionary<string, string> DeclaredNamespaces => _declared;
+
+    /// <summary>
+    /// Creates the override for the tree under <paramref name="root"/>, checking the prefix supplied
+    /// for every namespace the tree uses before anything is written.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">A supplied prefix is already bound to another namespace.</exception>
+    /// <exception cref="XmlException">A supplied prefix is not a valid XML name.</exception>
+    public static NamespacePrefixOverride Create(OpenXmlElement root, IOpenXmlNamespacePrefixFeature feature, IOpenXmlNamespaceResolver resolver)
+    {
+        var declared = new Dictionary<string, string>(StringComparer.Ordinal);
+        var namespaces = new HashSet<string>(StringComparer.Ordinal);
+
+        // Consecutive elements almost always share one namespace string instance, so a reference
+        // check skips hashing the URI for the vast majority of the tree.
+        string? previous = null;
+
+        Collect(root, declared, namespaces, ref previous);
+
+        foreach (var element in root.Descendants())
+        {
+            Collect(element, declared, namespaces, ref previous);
+        }
+
+        var result = new NamespacePrefixOverride(feature, resolver, declared);
+
+        foreach (var namespaceUri in namespaces)
+        {
+            result.TryGetPrefix(namespaceUri, out _);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Attempts to get the prefix the feature supplies for <paramref name="namespaceUri"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The supplied prefix is already bound to another namespace.</exception>
+    /// <exception cref="XmlException">The supplied prefix is not a valid XML name.</exception>
+    public bool TryGetPrefix(string namespaceUri, out string prefix)
+    {
+        if (_feature.TryGetPrefix(namespaceUri, out var overridden))
+        {
+            // Tolerate a third-party feature that reports success with a null prefix.
+            prefix = overridden ?? string.Empty;
+
+            if (prefix.Length > 0)
+            {
+                EnsureAvailable(namespaceUri, prefix);
+            }
+
+            return true;
+        }
+
+        prefix = string.Empty;
+        return false;
+    }
+
+    private static void Collect(OpenXmlElement element, Dictionary<string, string> declared, HashSet<string> namespaces, ref string? previous)
+    {
+        if (element.NamespaceDeclField is not null)
+        {
+            foreach (var declaration in element.NamespaceDeclField)
+            {
+                if (declaration.Key.Length > 0 && !declared.ContainsKey(declaration.Key))
+                {
+                    declared.Add(declaration.Key, declaration.Value);
+                }
+            }
+        }
+
+        var namespaceUri = element.NamespaceUri;
+
+        if (!ReferenceEquals(namespaceUri, previous) && !string.IsNullOrEmpty(namespaceUri))
+        {
+            namespaces.Add(namespaceUri);
+            previous = namespaceUri;
+        }
+    }
+
+    private void EnsureAvailable(string namespaceUri, string prefix)
+    {
+        if (_validated.TryGetValue(namespaceUri, out var checkedPrefix) && string.Equals(checkedPrefix, prefix, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        XmlConvert.VerifyNCName(prefix);
+
+        var boundTo = _resolver.LookupNamespace(prefix);
+
+        if (boundTo is null)
+        {
+            _declared.TryGetValue(prefix, out boundTo);
+        }
+
+        if (boundTo is not null && !string.Equals(boundTo, namespaceUri, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(SR.Format(ExceptionMessages.Fmt_NamespacePrefixIsReserved, prefix, namespaceUri, boundTo));
+        }
+
+        _validated[namespaceUri] = prefix;
+    }
+}

--- a/src/DocumentFormat.OpenXml.Framework/Features/NamespacePrefixOverrideXmlWriter.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/NamespacePrefixOverrideXmlWriter.cs
@@ -1,0 +1,165 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Xml;
+
+namespace DocumentFormat.OpenXml.Features;
+
+/// <summary>
+/// An <see cref="XmlWriter"/> decorator that applies an <see cref="IOpenXmlNamespacePrefixFeature"/>
+/// to the elements and namespace declarations written through it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The override is applied here rather than while resolving each element's prefix so that it cannot
+/// be undone by the writer's own namespace scope. A namespace-qualified attribute forces the
+/// underlying writer to declare the built-in prefix on its element - <c>w:rsidR</c> needs a prefix,
+/// and an empty one would mean "no namespace" - and from that point
+/// <see cref="XmlWriter.LookupPrefix(string)"/> reports that prefix for the namespace. Any decision
+/// made from the writer's scope would therefore silently revert to the built-in prefix for the rest
+/// of the subtree. Forcing the prefix at the point of writing keeps every element consistent
+/// regardless of what is declared around it.
+/// </para>
+/// <para>
+/// Attributes and namespace declarations pass through untouched. An empty prefix on an attribute
+/// means "no namespace" rather than "the default namespace", so a qualified attribute must keep a
+/// real prefix - and a declaration binding a prefix to an overridden namespace is left in place.
+/// Binding both a prefix and the default prefix to one namespace is legal, it does not affect
+/// element names once the prefix is forced here, and keeping it is what lets a qualified attribute
+/// resolve against the root instead of forcing a fresh declaration onto every element that carries
+/// one. Dropping such declarations would also strand any <c>mc:Ignorable</c> or
+/// <c>mc:Choice/@Requires</c> value that names the prefix.
+/// </para>
+/// </remarks>
+internal sealed class NamespacePrefixOverrideXmlWriter : XmlWriter
+{
+    private readonly XmlWriter _writer;
+    private readonly IOpenXmlNamespacePrefixFeature _feature;
+    private readonly IOpenXmlNamespaceResolver _resolver;
+
+    // Namespaces whose supplied prefix has already been checked for a collision.
+    private readonly HashSet<string> _validated = new(StringComparer.Ordinal);
+
+    public NamespacePrefixOverrideXmlWriter(XmlWriter writer, IOpenXmlNamespacePrefixFeature feature, IOpenXmlNamespaceResolver resolver)
+    {
+        _writer = writer;
+        _feature = feature;
+        _resolver = resolver;
+    }
+
+    public override WriteState WriteState => _writer.WriteState;
+
+    public override string? XmlLang => _writer.XmlLang;
+
+    public override XmlSpace XmlSpace => _writer.XmlSpace;
+
+    public override XmlWriterSettings? Settings => _writer.Settings;
+
+    public override void WriteStartElement(string? prefix, string localName, string? ns)
+    {
+        // The empty namespace is excluded deliberately: a prefix cannot be bound to it, so honoring
+        // a feature that answered for it would produce "Cannot use a prefix with an empty namespace".
+        var resolved = !string.IsNullOrEmpty(ns) && TryGetPrefix(ns!, out var overridden) ? overridden : prefix;
+
+        _writer.WriteStartElement(resolved, localName, ns);
+    }
+
+    public override void WriteStartAttribute(string? prefix, string localName, string? ns)
+        => _writer.WriteStartAttribute(prefix, localName, ns);
+
+    public override void WriteEndAttribute() => _writer.WriteEndAttribute();
+
+    public override void WriteString(string? text) => _writer.WriteString(text);
+
+    public override void Flush() => _writer.Flush();
+
+    public override string? LookupPrefix(string ns) => _writer.LookupPrefix(ns);
+
+    public override void WriteBase64(byte[] buffer, int index, int count) => _writer.WriteBase64(buffer, index, count);
+
+    public override void WriteCData(string? text) => _writer.WriteCData(text);
+
+    public override void WriteCharEntity(char ch) => _writer.WriteCharEntity(ch);
+
+    public override void WriteChars(char[] buffer, int index, int count) => _writer.WriteChars(buffer, index, count);
+
+    public override void WriteComment(string? text) => _writer.WriteComment(text);
+
+    public override void WriteDocType(string name, string? pubid, string? sysid, string? subset) => _writer.WriteDocType(name, pubid, sysid, subset);
+
+    public override void WriteEndDocument() => _writer.WriteEndDocument();
+
+    public override void WriteEndElement() => _writer.WriteEndElement();
+
+    public override void WriteEntityRef(string name) => _writer.WriteEntityRef(name);
+
+    public override void WriteFullEndElement() => _writer.WriteFullEndElement();
+
+    public override void WriteProcessingInstruction(string name, string? text) => _writer.WriteProcessingInstruction(name, text);
+
+    public override void WriteRaw(string data) => _writer.WriteRaw(data);
+
+    public override void WriteRaw(char[] buffer, int index, int count) => _writer.WriteRaw(buffer, index, count);
+
+    public override void WriteStartDocument() => _writer.WriteStartDocument();
+
+    public override void WriteStartDocument(bool standalone) => _writer.WriteStartDocument(standalone);
+
+    public override void WriteSurrogateCharEntity(char lowChar, char highChar) => _writer.WriteSurrogateCharEntity(lowChar, highChar);
+
+    public override void WriteWhitespace(string? ws) => _writer.WriteWhitespace(ws);
+
+    /// <summary>
+    /// Does nothing. The wrapped writer is owned by the caller and outlives this decorator.
+    /// </summary>
+    public override void Close()
+    {
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        // The wrapped writer is owned by the caller, so it is deliberately not disposed here.
+        base.Dispose(disposing);
+    }
+
+    private bool TryGetPrefix(string namespaceUri, out string prefix)
+    {
+        if (_feature.TryGetPrefix(namespaceUri, out var overridden))
+        {
+            // Tolerate a third-party feature that reports success with a null prefix.
+            prefix = overridden ?? string.Empty;
+
+            if (prefix.Length > 0 && _validated.Add(namespaceUri))
+            {
+                ThrowIfPrefixIsReserved(namespaceUri, prefix);
+            }
+
+            return true;
+        }
+
+        prefix = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Rejects a prefix that another Open XML namespace already owns.
+    /// </summary>
+    /// <remarks>
+    /// Taking such a prefix has no good outcome. When the other namespace is declared on the same
+    /// element the writer rejects it outright ("the prefix cannot be redefined"); when it is declared
+    /// further out the writer silently rebinds that namespace to a generated prefix, so
+    /// <c>r:id</c> ships as <c>p3:id</c> with no error at all. Callers cannot be expected to know
+    /// which prefixes a loaded document uses, so this is reported rather than left to the writer.
+    /// </remarks>
+    private void ThrowIfPrefixIsReserved(string namespaceUri, string prefix)
+    {
+        var reservedFor = _resolver.LookupNamespace(prefix);
+
+        if (reservedFor is not null && !string.Equals(reservedFor, namespaceUri, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(SR.Format(ExceptionMessages.Fmt_NamespacePrefixIsReserved, prefix, namespaceUri, reservedFor));
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml.Framework/Features/NamespacePrefixOverrideXmlWriter.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/NamespacePrefixOverrideXmlWriter.cs
@@ -1,15 +1,14 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Xml;
 
 namespace DocumentFormat.OpenXml.Features;
 
 /// <summary>
-/// An <see cref="XmlWriter"/> decorator that applies an <see cref="IOpenXmlNamespacePrefixFeature"/>
-/// to the elements and namespace declarations written through it.
+/// An <see cref="XmlWriter"/> decorator that applies a <see cref="NamespacePrefixOverride"/> to the
+/// elements written through it.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -33,133 +32,46 @@ namespace DocumentFormat.OpenXml.Features;
 /// <c>mc:Choice/@Requires</c> value that names the prefix.
 /// </para>
 /// </remarks>
-internal sealed class NamespacePrefixOverrideXmlWriter : XmlWriter
+internal sealed class NamespacePrefixOverrideXmlWriter : ForwardingXmlWriter
 {
-    private readonly XmlWriter _writer;
-    private readonly IOpenXmlNamespacePrefixFeature _feature;
-    private readonly IOpenXmlNamespaceResolver _resolver;
+    private readonly NamespacePrefixOverride _override;
 
-    // Namespaces whose supplied prefix has already been checked for a collision.
-    private readonly HashSet<string> _validated = new(StringComparer.Ordinal);
-
-    public NamespacePrefixOverrideXmlWriter(XmlWriter writer, IOpenXmlNamespacePrefixFeature feature, IOpenXmlNamespaceResolver resolver)
+    public NamespacePrefixOverrideXmlWriter(XmlWriter writer, NamespacePrefixOverride @override)
+        : base(writer)
     {
-        _writer = writer;
-        _feature = feature;
-        _resolver = resolver;
+        _override = @override;
     }
 
-    public override WriteState WriteState => _writer.WriteState;
+    /// <summary>
+    /// Gets the namespace resolver of the part being saved.
+    /// </summary>
+    /// <remarks>
+    /// Once an overridden namespace is bound as the default namespace, <see cref="XmlWriter.LookupPrefix(string)"/>
+    /// answers with the empty prefix, which <see cref="OpenXmlElement.WriteTo(XmlWriter)"/> treats
+    /// as "not found" and resolves through the element's features instead. An element's features
+    /// are not cached: each lookup walks to the part root and through the feature chain. Every
+    /// element written under the override would pay that walk, so they read the resolver from here.
+    /// </remarks>
+    internal IOpenXmlNamespaceResolver Resolver => _override.Resolver;
 
-    public override string? XmlLang => _writer.XmlLang;
-
-    public override XmlSpace XmlSpace => _writer.XmlSpace;
-
-    public override XmlWriterSettings? Settings => _writer.Settings;
+    /// <summary>
+    /// Gets the namespace declarations the override collected from the tree, keyed by prefix.
+    /// </summary>
+    internal Dictionary<string, string> DeclaredNamespaces => _override.DeclaredNamespaces;
 
     public override void WriteStartElement(string? prefix, string localName, string? ns)
     {
         // The empty namespace is excluded deliberately: a prefix cannot be bound to it, so honoring
         // a feature that answered for it would produce "Cannot use a prefix with an empty namespace".
-        var resolved = !string.IsNullOrEmpty(ns) && TryGetPrefix(ns!, out var overridden) ? overridden : prefix;
+        var resolved = !string.IsNullOrEmpty(ns) && _override.TryGetPrefix(ns!, out var overridden) ? overridden : prefix;
 
-        _writer.WriteStartElement(resolved, localName, ns);
+        Inner.WriteStartElement(resolved, localName, ns);
     }
-
-    public override void WriteStartAttribute(string? prefix, string localName, string? ns)
-        => _writer.WriteStartAttribute(prefix, localName, ns);
-
-    public override void WriteEndAttribute() => _writer.WriteEndAttribute();
-
-    public override void WriteString(string? text) => _writer.WriteString(text);
-
-    public override void Flush() => _writer.Flush();
-
-    public override string? LookupPrefix(string ns) => _writer.LookupPrefix(ns);
-
-    public override void WriteBase64(byte[] buffer, int index, int count) => _writer.WriteBase64(buffer, index, count);
-
-    public override void WriteCData(string? text) => _writer.WriteCData(text);
-
-    public override void WriteCharEntity(char ch) => _writer.WriteCharEntity(ch);
-
-    public override void WriteChars(char[] buffer, int index, int count) => _writer.WriteChars(buffer, index, count);
-
-    public override void WriteComment(string? text) => _writer.WriteComment(text);
-
-    public override void WriteDocType(string name, string? pubid, string? sysid, string? subset) => _writer.WriteDocType(name, pubid, sysid, subset);
-
-    public override void WriteEndDocument() => _writer.WriteEndDocument();
-
-    public override void WriteEndElement() => _writer.WriteEndElement();
-
-    public override void WriteEntityRef(string name) => _writer.WriteEntityRef(name);
-
-    public override void WriteFullEndElement() => _writer.WriteFullEndElement();
-
-    public override void WriteProcessingInstruction(string name, string? text) => _writer.WriteProcessingInstruction(name, text);
-
-    public override void WriteRaw(string data) => _writer.WriteRaw(data);
-
-    public override void WriteRaw(char[] buffer, int index, int count) => _writer.WriteRaw(buffer, index, count);
-
-    public override void WriteStartDocument() => _writer.WriteStartDocument();
-
-    public override void WriteStartDocument(bool standalone) => _writer.WriteStartDocument(standalone);
-
-    public override void WriteSurrogateCharEntity(char lowChar, char highChar) => _writer.WriteSurrogateCharEntity(lowChar, highChar);
-
-    public override void WriteWhitespace(string? ws) => _writer.WriteWhitespace(ws);
 
     /// <summary>
     /// Does nothing. The wrapped writer is owned by the caller and outlives this decorator.
     /// </summary>
     public override void Close()
     {
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        // The wrapped writer is owned by the caller, so it is deliberately not disposed here.
-        base.Dispose(disposing);
-    }
-
-    private bool TryGetPrefix(string namespaceUri, out string prefix)
-    {
-        if (_feature.TryGetPrefix(namespaceUri, out var overridden))
-        {
-            // Tolerate a third-party feature that reports success with a null prefix.
-            prefix = overridden ?? string.Empty;
-
-            if (prefix.Length > 0 && _validated.Add(namespaceUri))
-            {
-                ThrowIfPrefixIsReserved(namespaceUri, prefix);
-            }
-
-            return true;
-        }
-
-        prefix = string.Empty;
-        return false;
-    }
-
-    /// <summary>
-    /// Rejects a prefix that another Open XML namespace already owns.
-    /// </summary>
-    /// <remarks>
-    /// Taking such a prefix has no good outcome. When the other namespace is declared on the same
-    /// element the writer rejects it outright ("the prefix cannot be redefined"); when it is declared
-    /// further out the writer silently rebinds that namespace to a generated prefix, so
-    /// <c>r:id</c> ships as <c>p3:id</c> with no error at all. Callers cannot be expected to know
-    /// which prefixes a loaded document uses, so this is reported rather than left to the writer.
-    /// </remarks>
-    private void ThrowIfPrefixIsReserved(string namespaceUri, string prefix)
-    {
-        var reservedFor = _resolver.LookupNamespace(prefix);
-
-        if (reservedFor is not null && !string.Equals(reservedFor, namespaceUri, StringComparison.Ordinal))
-        {
-            throw new InvalidOperationException(SR.Format(ExceptionMessages.Fmt_NamespacePrefixIsReserved, prefix, namespaceUri, reservedFor));
-        }
     }
 }

--- a/src/DocumentFormat.OpenXml.Framework/Features/OpenXmlNamespacePrefix.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Features/OpenXmlNamespacePrefix.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace DocumentFormat.OpenXml.Features;
+
+/// <summary>
+/// Factory methods for <see cref="IOpenXmlNamespacePrefixFeature"/> implementations.
+/// </summary>
+public static class OpenXmlNamespacePrefix
+{
+    /// <summary>
+    /// Creates a feature that writes the supplied namespaces as the default (unprefixed) namespace
+    /// and leaves every other namespace on its built-in prefix.
+    /// </summary>
+    /// <param name="namespaceUris">The namespaces to write unprefixed.</param>
+    /// <returns>A feature that can be registered on a package's <see cref="IFeatureCollection"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="namespaceUris"/> is, or contains, <see langword="null"/>.</exception>
+    public static IOpenXmlNamespacePrefixFeature DefaultFor(params string[] namespaceUris)
+    {
+        if (namespaceUris is null)
+        {
+            throw new ArgumentNullException(nameof(namespaceUris));
+        }
+
+        foreach (var namespaceUri in namespaceUris)
+        {
+            if (namespaceUri is null)
+            {
+                throw new ArgumentNullException(nameof(namespaceUris), ExceptionMessages.NamespaceUriCannotBeNull);
+            }
+        }
+
+        return new DefaultNamespaceFeature(namespaceUris);
+    }
+
+    /// <summary>
+    /// Creates a feature from a callback that maps a namespace to the prefix used to write it.
+    /// </summary>
+    /// <param name="resolver">
+    /// Returns the prefix for a namespace, <see cref="string.Empty"/> to write it as the default
+    /// namespace, or <see langword="null"/> to use the built-in prefix.
+    /// </param>
+    /// <returns>A feature that can be registered on a package's <see cref="IFeatureCollection"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="resolver"/> is <see langword="null"/>.</exception>
+    public static IOpenXmlNamespacePrefixFeature Create(Func<string, string?> resolver)
+    {
+        if (resolver is null)
+        {
+            throw new ArgumentNullException(nameof(resolver));
+        }
+
+        return new DelegateFeature(resolver);
+    }
+
+    private sealed class DefaultNamespaceFeature : IOpenXmlNamespacePrefixFeature
+    {
+        private readonly HashSet<string> _namespaces;
+
+        public DefaultNamespaceFeature(string[] namespaceUris)
+        {
+            _namespaces = new HashSet<string>(namespaceUris, StringComparer.Ordinal);
+        }
+
+        public bool TryGetPrefix(string namespaceUri, out string prefix)
+        {
+            if (_namespaces.Contains(namespaceUri))
+            {
+                prefix = string.Empty;
+                return true;
+            }
+
+            prefix = string.Empty;
+            return false;
+        }
+    }
+
+    private sealed class DelegateFeature : IOpenXmlNamespacePrefixFeature
+    {
+        private readonly Func<string, string?> _resolver;
+
+        public DelegateFeature(Func<string, string?> resolver)
+        {
+            _resolver = resolver;
+        }
+
+        public bool TryGetPrefix(string namespaceUri, out string prefix)
+        {
+            if (_resolver(namespaceUri) is { } result)
+            {
+                prefix = result;
+                return true;
+            }
+
+            prefix = string.Empty;
+            return false;
+        }
+    }
+}

--- a/src/DocumentFormat.OpenXml.Framework/ForwardingXmlWriter.cs
+++ b/src/DocumentFormat.OpenXml.Framework/ForwardingXmlWriter.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Xml;
+
+namespace DocumentFormat.OpenXml
+{
+    /// <summary>
+    /// An <see cref="XmlWriter"/> that forwards every call to an inner writer, so that a decorator
+    /// only has to override the calls it intercepts.
+    /// </summary>
+    internal abstract class ForwardingXmlWriter : XmlWriter
+    {
+        protected ForwardingXmlWriter(XmlWriter inner)
+        {
+            Inner = inner;
+        }
+
+        /// <summary>
+        /// Gets the writer that calls are forwarded to.
+        /// </summary>
+        protected XmlWriter Inner { get; }
+
+        public override WriteState WriteState => Inner.WriteState;
+
+        public override XmlWriterSettings? Settings => Inner.Settings;
+
+        public override string? XmlLang => Inner.XmlLang;
+
+        public override XmlSpace XmlSpace => Inner.XmlSpace;
+
+        public override void Flush() => Inner.Flush();
+
+        public override string? LookupPrefix(string ns) => Inner.LookupPrefix(ns);
+
+        public override void WriteBase64(byte[] buffer, int index, int count) => Inner.WriteBase64(buffer, index, count);
+
+        public override void WriteCData(string? text) => Inner.WriteCData(text);
+
+        public override void WriteCharEntity(char ch) => Inner.WriteCharEntity(ch);
+
+        public override void WriteChars(char[] buffer, int index, int count) => Inner.WriteChars(buffer, index, count);
+
+        public override void WriteComment(string? text) => Inner.WriteComment(text);
+
+        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset) => Inner.WriteDocType(name, pubid, sysid, subset);
+
+        public override void WriteEndAttribute() => Inner.WriteEndAttribute();
+
+        public override void WriteEndDocument() => Inner.WriteEndDocument();
+
+        public override void WriteEndElement() => Inner.WriteEndElement();
+
+        public override void WriteEntityRef(string name) => Inner.WriteEntityRef(name);
+
+        public override void WriteFullEndElement() => Inner.WriteFullEndElement();
+
+        public override void WriteProcessingInstruction(string name, string? text) => Inner.WriteProcessingInstruction(name, text);
+
+        public override void WriteRaw(string data) => Inner.WriteRaw(data);
+
+        public override void WriteRaw(char[] buffer, int index, int count) => Inner.WriteRaw(buffer, index, count);
+
+        public override void WriteStartAttribute(string? prefix, string localName, string? ns) => Inner.WriteStartAttribute(prefix, localName, ns);
+
+        public override void WriteStartDocument() => Inner.WriteStartDocument();
+
+        public override void WriteStartDocument(bool standalone) => Inner.WriteStartDocument(standalone);
+
+        public override void WriteStartElement(string? prefix, string localName, string? ns) => Inner.WriteStartElement(prefix, localName, ns);
+
+        public override void WriteString(string? text) => Inner.WriteString(text);
+
+        public override void WriteSurrogateCharEntity(char lowChar, char highChar) => Inner.WriteSurrogateCharEntity(lowChar, highChar);
+
+        public override void WriteWhitespace(string? ws) => Inner.WriteWhitespace(ws);
+
+        public override void Close() => Inner.Close();
+    }
+}

--- a/src/DocumentFormat.OpenXml.Framework/OpenXmlElement.cs
+++ b/src/DocumentFormat.OpenXml.Framework/OpenXmlElement.cs
@@ -1093,7 +1093,7 @@ namespace DocumentFormat.OpenXml
                 // in this case, we use the predefined prefix
                 if (string.IsNullOrEmpty(prefix))
                 {
-                    prefix = Features.GetNamespaceResolver().LookupPrefix(QName.Namespace.Uri);
+                    prefix = GetNamespaceResolver(xmlWriter).LookupPrefix(QName.Namespace.Uri);
                 }
 
                 xmlWriter.WriteStartElement(prefix, LocalName, NamespaceUri);
@@ -1106,6 +1106,19 @@ namespace DocumentFormat.OpenXml
                 xmlWriter.WriteRaw(RawOuterXml);
             }
         }
+
+        /// <summary>
+        /// Gets the namespace resolver to use while writing to <paramref name="xmlWriter"/>.
+        /// </summary>
+        /// <remarks>
+        /// A prefix override binds a namespace as the default namespace, after which the writer
+        /// reports the empty prefix for it and every element below the root falls back to the
+        /// resolver. Resolving it through <see cref="Features"/> walks to the part root and through
+        /// the feature chain each time, so the resolver the root already resolved is reused instead.
+        /// The element's features are read-only and defer to the part, so the two are the same instance.
+        /// </remarks>
+        private IOpenXmlNamespaceResolver GetNamespaceResolver(XmlWriter xmlWriter)
+            => xmlWriter is NamespacePrefixOverrideXmlWriter overrideWriter ? overrideWriter.Resolver : Features.GetNamespaceResolver();
 
         /// <summary>
         /// Appends each element from a list of elements to the end of the current element's list of child elements.
@@ -1477,7 +1490,7 @@ namespace DocumentFormat.OpenXml
                             prefix = xmlWriter.LookupPrefix(ns);
                             if (string.IsNullOrEmpty(prefix))
                             {
-                                prefix = Features.GetNamespaceResolver().LookupPrefix(attribute.Property.QName.Namespace.Uri);
+                                prefix = GetNamespaceResolver(xmlWriter).LookupPrefix(attribute.Property.QName.Namespace.Uri);
                             }
                         }
 
@@ -1489,7 +1502,23 @@ namespace DocumentFormat.OpenXml
 
                 foreach (var attribute in ExtendedAttributes)
                 {
-                    xmlWriter.WriteAttributeString(attribute.Prefix, attribute.LocalName, attribute.NamespaceUri, attribute.Value);
+                    var prefix = attribute.Prefix;
+
+                    // A qualified attribute needs a real prefix - an empty one means "no namespace".
+                    // When the namespace is bound as the default namespace the writer has no prefix
+                    // to offer and would generate one, so fall back to the built-in prefix the way
+                    // the parsed attributes above do.
+                    if (string.IsNullOrEmpty(prefix) && !string.IsNullOrEmpty(attribute.NamespaceUri))
+                    {
+                        prefix = xmlWriter.LookupPrefix(attribute.NamespaceUri);
+
+                        if (string.IsNullOrEmpty(prefix))
+                        {
+                            prefix = GetNamespaceResolver(xmlWriter).LookupPrefix(attribute.NamespaceUri);
+                        }
+                    }
+
+                    xmlWriter.WriteAttributeString(prefix, attribute.LocalName, attribute.NamespaceUri, attribute.Value);
                 }
 
                 WriteMCAttribute(xmlWriter);

--- a/src/DocumentFormat.OpenXml.Framework/OpenXmlPartRootElement.cs
+++ b/src/DocumentFormat.OpenXml.Framework/OpenXmlPartRootElement.cs
@@ -191,10 +191,14 @@ namespace DocumentFormat.OpenXml
                 throw new ArgumentNullException(nameof(openXmlPart));
             }
 
+            // Resolved before the part is opened: opening truncates it, and a prefix the registered
+            // feature cannot be given is reported while the previous content is still intact.
+            var prefixOverride = CreateNamespacePrefixOverride();
+
             // If we're saving the existing root to the the part, we don't need to unload the root as they're already equal
             using var partStream = openXmlPart.GetStream(FileMode.Create, unloadRootOnChange: !ReferenceEquals(this, openXmlPart.PartRootElement));
 
-            Save(partStream);
+            Save(partStream, prefixOverride);
         }
 
         /// <summary>
@@ -203,7 +207,9 @@ namespace DocumentFormat.OpenXml
         /// <param name="stream">
         /// The stream to which to save the XML.
         /// </param>
-        public void Save(Stream stream)
+        public void Save(Stream stream) => Save(stream, CreateNamespacePrefixOverride());
+
+        private void Save(Stream stream, NamespacePrefixOverride? prefixOverride)
         {
             var settings = new XmlWriterSettings
             {
@@ -217,13 +223,15 @@ namespace DocumentFormat.OpenXml
             events?.OnChange(EventType.Saving, OpenXmlPart);
 
             using (var xmlWriter = new XmlDOMTextWriter(stream, settings))
+            using (var overrideWriter = prefixOverride is null ? null : new NamespacePrefixOverrideXmlWriter(xmlWriter, prefixOverride))
             {
                 if (_standaloneDeclaration is not null)
                 {
                     xmlWriter.WriteStartDocument(_standaloneDeclaration.Value);
                 }
 
-                WriteTo(xmlWriter);
+                // WriteTo recognizes the decorator and does not wrap the writer a second time.
+                WriteTo(overrideWriter ?? (XmlWriter)xmlWriter);
 
                 // Do not call WriteEndDocument if this root element is not parsed.
                 // In that case, the WriteTo() will just call WriteRaw() with the raw xml,
@@ -306,15 +314,30 @@ namespace DocumentFormat.OpenXml
             // A prefix override is applied once for the whole part rather than per element: the
             // decorator forces the prefix as each element is written, which the writer's namespace
             // scope cannot undo, and costs a single feature lookup per save when none is registered.
-            if (xmlWriter is not NamespacePrefixOverrideXmlWriter && Features.Get<IOpenXmlNamespacePrefixFeature>() is { } feature)
+            if (xmlWriter is not NamespacePrefixOverrideXmlWriter && CreateNamespacePrefixOverride() is { } prefixOverride)
             {
-                using var overrideWriter = new NamespacePrefixOverrideXmlWriter(xmlWriter, feature, Features.GetNamespaceResolver());
+                using var overrideWriter = new NamespacePrefixOverrideXmlWriter(xmlWriter, prefixOverride);
 
                 WriteToCore(overrideWriter);
                 return;
             }
 
             WriteToCore(xmlWriter);
+        }
+
+        /// <summary>
+        /// Creates the prefix override for this tree when an <see cref="IOpenXmlNamespacePrefixFeature"/>
+        /// is registered and the root is parsed, checking every prefix it supplies; otherwise returns
+        /// <see langword="null"/>. An unparsed root is written verbatim, so no override applies to it.
+        /// </summary>
+        private NamespacePrefixOverride? CreateNamespacePrefixOverride()
+        {
+            if (!XmlParsed || Features.Get<IOpenXmlNamespacePrefixFeature>() is not { } feature)
+            {
+                return null;
+            }
+
+            return NamespacePrefixOverride.Create(this, feature, Features.GetNamespaceResolver());
         }
 
         private void WriteToCore(XmlWriter xmlWriter)
@@ -356,21 +379,13 @@ namespace DocumentFormat.OpenXml
         {
             if (WriteAllNamespaceOnRoot)
             {
-                var namespaces = new Dictionary<string, string>();
-
-                foreach (OpenXmlElement element in Descendants())
-                {
-                    if (element.NamespaceDeclField is not null)
-                    {
-                        foreach (var item in element.NamespaceDeclField)
-                        {
-                            if (!namespaces.ContainsKey(item.Key))
-                            {
-                                namespaces.Add(item.Key, item.Value);
-                            }
-                        }
-                    }
-                }
+                // A prefix override has already walked the tree to check its prefixes and collected
+                // the declarations on the way; reuse them rather than walking the tree a second time.
+                // Its map also holds the root's own declarations, which the loop below skips anyway
+                // because the root declares them locally.
+                var namespaces = xmlWrite is NamespacePrefixOverrideXmlWriter overrideWriter
+                    ? overrideWriter.DeclaredNamespaces
+                    : CollectDescendantNamespaceDeclarations();
 
                 foreach (var namespacePair in namespaces)
                 {
@@ -385,6 +400,27 @@ namespace DocumentFormat.OpenXml
                     }
                 }
             }
+        }
+
+        private Dictionary<string, string> CollectDescendantNamespaceDeclarations()
+        {
+            var namespaces = new Dictionary<string, string>();
+
+            foreach (OpenXmlElement element in Descendants())
+            {
+                if (element.NamespaceDeclField is not null)
+                {
+                    foreach (var item in element.NamespaceDeclField)
+                    {
+                        if (!namespaces.ContainsKey(item.Key))
+                        {
+                            namespaces.Add(item.Key, item.Value);
+                        }
+                    }
+                }
+            }
+
+            return namespaces;
         }
 
         /// <summary>

--- a/src/DocumentFormat.OpenXml.Framework/OpenXmlPartRootElement.cs
+++ b/src/DocumentFormat.OpenXml.Framework/OpenXmlPartRootElement.cs
@@ -292,43 +292,63 @@ namespace DocumentFormat.OpenXml
                 throw new ArgumentNullException(nameof(xmlWriter));
             }
 
-            if (XmlParsed)
+            // An unparsed root is content the caller supplied as raw XML; it is copied out verbatim,
+            // so a prefix override does not reach it. Forcing a parse to close that gap would turn a
+            // byte-for-byte copy into a re-serialization, and raw XML the SDK can reproduce exactly
+            // is not always XML it can re-read - registering a purely cosmetic feature would then
+            // start throwing on saves that work today.
+            if (!XmlParsed)
             {
-                // check the namespace mapping defined in this node first. because till now xmlWriter don't know the mapping defined in the current node.
-                var prefix = LookupNamespaceLocal(NamespaceUri);
+                xmlWriter.WriteRaw(RawOuterXml);
+                return;
+            }
 
-                // if not defined in the current node, try the xmlWriter
-                if (Parent is not null && prefix.IsNullOrEmpty())
-                {
-                    prefix = xmlWriter.LookupPrefix(NamespaceUri);
-                }
+            // A prefix override is applied once for the whole part rather than per element: the
+            // decorator forces the prefix as each element is written, which the writer's namespace
+            // scope cannot undo, and costs a single feature lookup per save when none is registered.
+            if (xmlWriter is not NamespacePrefixOverrideXmlWriter && Features.Get<IOpenXmlNamespacePrefixFeature>() is { } feature)
+            {
+                using var overrideWriter = new NamespacePrefixOverrideXmlWriter(xmlWriter, feature, Features.GetNamespaceResolver());
 
-                // if xmlWriter didn't find it, it means the node is constructed by user and is not in the tree yet
-                // in this case, we use the predefined prefix
-                if (prefix.IsNullOrEmpty())
-                {
-                    prefix = Features.GetNamespaceResolver().LookupPrefix(QName.Namespace.Uri);
-                }
+                WriteToCore(overrideWriter);
+                return;
+            }
 
-                xmlWriter.WriteStartElement(prefix, LocalName, NamespaceUri);
+            WriteToCore(xmlWriter);
+        }
 
-                // fix bug #225919, write out all namespace into to root
-                WriteNamespaceAtributes(xmlWriter);
-                WriteAttributesTo(xmlWriter);
+        private void WriteToCore(XmlWriter xmlWriter)
+        {
+            // check the namespace mapping defined in this node first. because till now xmlWriter don't know the mapping defined in the current node.
+            var prefix = LookupNamespaceLocal(NamespaceUri);
 
-                if (HasChildren || !string.IsNullOrEmpty(InnerText))
-                {
-                    WriteContentTo(xmlWriter);
-                    xmlWriter.WriteFullEndElement();
-                }
-                else
-                {
-                    xmlWriter.WriteEndElement();
-                }
+            // if not defined in the current node, try the xmlWriter
+            if (Parent is not null && prefix.IsNullOrEmpty())
+            {
+                prefix = xmlWriter.LookupPrefix(NamespaceUri);
+            }
+
+            // if xmlWriter didn't find it, it means the node is constructed by user and is not in the tree yet
+            // in this case, we use the predefined prefix
+            if (prefix.IsNullOrEmpty())
+            {
+                prefix = Features.GetNamespaceResolver().LookupPrefix(QName.Namespace.Uri);
+            }
+
+            xmlWriter.WriteStartElement(prefix, LocalName, NamespaceUri);
+
+            // fix bug #225919, write out all namespace into to root
+            WriteNamespaceAtributes(xmlWriter);
+            WriteAttributesTo(xmlWriter);
+
+            if (HasChildren || !string.IsNullOrEmpty(InnerText))
+            {
+                WriteContentTo(xmlWriter);
+                xmlWriter.WriteFullEndElement();
             }
             else
             {
-                xmlWriter.WriteRaw(RawOuterXml);
+                xmlWriter.WriteEndElement();
             }
         }
 

--- a/src/DocumentFormat.OpenXml.Framework/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/DocumentFormat.OpenXml.Framework/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 ﻿#nullable enable
+DocumentFormat.OpenXml.Features.IOpenXmlNamespacePrefixFeature
+DocumentFormat.OpenXml.Features.IOpenXmlNamespacePrefixFeature.TryGetPrefix(string! namespaceUri, out string! prefix) -> bool
+DocumentFormat.OpenXml.Features.NamespacePrefixFeatureExtensions
+DocumentFormat.OpenXml.Features.OpenXmlNamespacePrefix
+static DocumentFormat.OpenXml.Features.NamespacePrefixFeatureExtensions.SetNamespacePrefixOverride(this DocumentFormat.OpenXml.Features.IFeatureCollection! features, DocumentFormat.OpenXml.Features.IOpenXmlNamespacePrefixFeature! feature) -> void
+static DocumentFormat.OpenXml.Features.NamespacePrefixFeatureExtensions.SetNamespacePrefixOverride(this DocumentFormat.OpenXml.Features.IFeatureCollection! features, System.Func<string!, string?>! resolver) -> void
+static DocumentFormat.OpenXml.Features.OpenXmlNamespacePrefix.Create(System.Func<string!, string?>! resolver) -> DocumentFormat.OpenXml.Features.IOpenXmlNamespacePrefixFeature!
+static DocumentFormat.OpenXml.Features.OpenXmlNamespacePrefix.DefaultFor(params string![]! namespaceUris) -> DocumentFormat.OpenXml.Features.IOpenXmlNamespacePrefixFeature!

--- a/src/DocumentFormat.OpenXml.Framework/Resources/ExceptionMessages.Designer.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Resources/ExceptionMessages.Designer.cs
@@ -775,7 +775,7 @@ namespace DocumentFormat.OpenXml {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The namespace prefix '{0}' supplied for '{1}' is already reserved for '{2}'..
+        ///   Looks up a localized string similar to The namespace prefix '{0}' supplied for '{1}' is already bound to '{2}'..
         /// </summary>
         internal static string Fmt_NamespacePrefixIsReserved {
             get {
@@ -789,15 +789,6 @@ namespace DocumentFormat.OpenXml {
         internal static string NamespaceUriCannotBeNull {
             get {
                 return ResourceManager.GetString("NamespaceUriCannotBeNull", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to This feature collection is read-only. Register the feature on the package instead, using OpenXmlPackage.Features..
-        /// </summary>
-        internal static string ReadOnlyFeatureCollection {
-            get {
-                return ResourceManager.GetString("ReadOnlyFeatureCollection", resourceCulture);
             }
         }
         

--- a/src/DocumentFormat.OpenXml.Framework/Resources/ExceptionMessages.Designer.cs
+++ b/src/DocumentFormat.OpenXml.Framework/Resources/ExceptionMessages.Designer.cs
@@ -775,6 +775,33 @@ namespace DocumentFormat.OpenXml {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The namespace prefix '{0}' supplied for '{1}' is already reserved for '{2}'..
+        /// </summary>
+        internal static string Fmt_NamespacePrefixIsReserved {
+            get {
+                return ResourceManager.GetString("Fmt_NamespacePrefixIsReserved", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A namespace URI cannot be null..
+        /// </summary>
+        internal static string NamespaceUriCannotBeNull {
+            get {
+                return ResourceManager.GetString("NamespaceUriCannotBeNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This feature collection is read-only. Register the feature on the package instead, using OpenXmlPackage.Features..
+        /// </summary>
+        internal static string ReadOnlyFeatureCollection {
+            get {
+                return ResourceManager.GetString("ReadOnlyFeatureCollection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Id conflicts with the Id of an existing relationship..
         /// </summary>
         internal static string RelationshipIdConflict {

--- a/src/DocumentFormat.OpenXml.Framework/Resources/ExceptionMessages.resx
+++ b/src/DocumentFormat.OpenXml.Framework/Resources/ExceptionMessages.resx
@@ -303,6 +303,15 @@
   <data name="ReaderInNullState" xml:space="preserve">
     <value>The reader is now positioned before the first element. Call OpenXmlReader.Read() before this operation.</value>
   </data>
+  <data name="Fmt_NamespacePrefixIsReserved" xml:space="preserve">
+    <value>The namespace prefix '{0}' supplied for '{1}' is already reserved for '{2}'. Writing both would either be rejected as a redefined prefix or silently rebind the other namespace. Choose a prefix that is not used by another Open XML namespace.</value>
+  </data>
+  <data name="NamespaceUriCannotBeNull" xml:space="preserve">
+    <value>A namespace URI cannot be null.</value>
+  </data>
+  <data name="ReadOnlyFeatureCollection" xml:space="preserve">
+    <value>This feature collection is read-only. Register the feature on the package instead, using OpenXmlPackage.Features.</value>
+  </data>
   <data name="RelationshipIdConflict" xml:space="preserve">
     <value>Id conflicts with the Id of an existing relationship.</value>
   </data>

--- a/src/DocumentFormat.OpenXml.Framework/Resources/ExceptionMessages.resx
+++ b/src/DocumentFormat.OpenXml.Framework/Resources/ExceptionMessages.resx
@@ -304,13 +304,10 @@
     <value>The reader is now positioned before the first element. Call OpenXmlReader.Read() before this operation.</value>
   </data>
   <data name="Fmt_NamespacePrefixIsReserved" xml:space="preserve">
-    <value>The namespace prefix '{0}' supplied for '{1}' is already reserved for '{2}'. Writing both would either be rejected as a redefined prefix or silently rebind the other namespace. Choose a prefix that is not used by another Open XML namespace.</value>
+    <value>The namespace prefix '{0}' supplied for '{1}' is already bound to '{2}'. Writing both would either be rejected as a redefined prefix or silently rebind the other namespace. Choose a prefix that is neither used by another Open XML namespace nor declared in the document.</value>
   </data>
   <data name="NamespaceUriCannotBeNull" xml:space="preserve">
     <value>A namespace URI cannot be null.</value>
-  </data>
-  <data name="ReadOnlyFeatureCollection" xml:space="preserve">
-    <value>This feature collection is read-only. Register the feature on the package instead, using OpenXmlPackage.Features.</value>
   </data>
   <data name="RelationshipIdConflict" xml:space="preserve">
     <value>Id conflicts with the Id of an existing relationship.</value>

--- a/src/DocumentFormat.OpenXml.Framework/XmlDOMTextWriter.cs
+++ b/src/DocumentFormat.OpenXml.Framework/XmlDOMTextWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -7,65 +7,27 @@ using System.Xml;
 
 namespace DocumentFormat.OpenXml
 {
-    internal class XmlDOMTextWriter : XmlWriter
+    internal class XmlDOMTextWriter : ForwardingXmlWriter
     {
-        private readonly XmlWriter _writer;
-
         public XmlDOMTextWriter(Stream stream)
+            : base(Create(stream))
         {
-            _writer = Create(stream);
         }
 
         public XmlDOMTextWriter(Stream stream, XmlWriterSettings settings)
+            : base(Create(stream, settings))
         {
-            _writer = Create(stream, settings);
         }
 
         public XmlDOMTextWriter(TextWriter w)
-        {
-            var xwSettings = new XmlWriterSettings
+            : base(Create(w, new XmlWriterSettings
             {
                 Encoding = w.Encoding,
                 OmitXmlDeclaration = true,
                 ConformanceLevel = ConformanceLevel.Fragment,
-            };
-
-            _writer = Create(w, xwSettings);
+            }))
+        {
         }
-
-        public override WriteState WriteState => _writer.WriteState;
-
-        public override void Flush() => _writer.Flush();
-
-        public override string? LookupPrefix(string ns) => _writer.LookupPrefix(ns);
-
-        public override void WriteBase64(byte[] buffer, int index, int count) => _writer.WriteBase64(buffer, index, count);
-
-        public override void WriteCData(string? text) => _writer.WriteCData(text);
-
-        public override void WriteCharEntity(char ch) => _writer.WriteCharEntity(ch);
-
-        public override void WriteChars(char[] buffer, int index, int count) => _writer.WriteChars(buffer, index, count);
-
-        public override void WriteComment(string? text) => _writer.WriteComment(text);
-
-        public override void WriteDocType(string name, string? pubid, string? sysid, string? subset) => _writer.WriteDocType(name, pubid, sysid, subset);
-
-        public override void WriteEndAttribute() => _writer.WriteEndAttribute();
-
-        public override void WriteEndDocument() => _writer.WriteEndDocument();
-
-        public override void WriteEndElement() => _writer.WriteEndElement();
-
-        public override void WriteEntityRef(string name) => _writer.WriteEntityRef(name);
-
-        public override void WriteFullEndElement() => _writer.WriteFullEndElement();
-
-        public override void WriteProcessingInstruction(string name, string? text) => _writer.WriteProcessingInstruction(name, text);
-
-        public override void WriteRaw(string data) => _writer.WriteRaw(data);
-
-        public override void WriteRaw(char[] buffer, int index, int count) => _writer.WriteRaw(buffer, index, count);
 
         public override void WriteStartAttribute(string? prefix, string localName, string? ns)
         {
@@ -89,12 +51,8 @@ namespace DocumentFormat.OpenXml
                 prefix = string.Empty;
             }
 
-            _writer.WriteStartAttribute(prefix, localName, ns);
+            Inner.WriteStartAttribute(prefix, localName, ns);
         }
-
-        public override void WriteStartDocument() => _writer.WriteStartDocument();
-
-        public override void WriteStartDocument(bool standalone) => _writer.WriteStartDocument(standalone);
 
         public override void WriteStartElement(string? prefix, string localName, string? ns)
         {
@@ -118,28 +76,16 @@ namespace DocumentFormat.OpenXml
                 prefix = string.Empty;
             }
 
-            _writer.WriteStartElement(prefix, localName, ns);
+            Inner.WriteStartElement(prefix, localName, ns);
         }
 
         public override void WriteString(string? text)
         {
             if (!string.IsNullOrEmpty(text))
             {
-                _writer.WriteString(text);
+                Inner.WriteString(text);
             }
         }
-
-        public override void WriteSurrogateCharEntity(char lowChar, char highChar) => _writer.WriteSurrogateCharEntity(lowChar, highChar);
-
-        public override void WriteWhitespace(string? ws) => _writer.WriteWhitespace(ws);
-
-        public override XmlWriterSettings? Settings => _writer.Settings;
-
-        public override string? XmlLang => _writer.XmlLang;
-
-        public override XmlSpace XmlSpace => _writer.XmlSpace;
-
-        public override void Close() => _writer.Close();
 
         protected override void Dispose(bool disposing)
         {
@@ -148,9 +94,9 @@ namespace DocumentFormat.OpenXml
             if (disposing)
             {
 #if NET35 || NET40
-                ((IDisposable)_writer).Dispose();
+                ((IDisposable)Inner).Dispose();
 #else
-                _writer.Dispose();
+                Inner.Dispose();
 #endif
             }
         }

--- a/test/DocumentFormat.OpenXml.Framework.Tests/NamespacePrefixOverrideTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/NamespacePrefixOverrideTests.cs
@@ -316,18 +316,19 @@ namespace DocumentFormat.OpenXml.Framework.Tests
             var builder = new StringBuilder();
             var element = new Worksheet(new SheetData());
 
+            var prefixOverride = NamespacePrefixOverride.Create(
+                element,
+                OpenXmlNamespacePrefix.Create(ns => ns.Length == 0 ? "p" : null),
+                new OpenXmlNamespaceResolver());
+
             using (var writer = XmlWriter.Create(builder, new XmlWriterSettings { OmitXmlDeclaration = true }))
-            using (var wrapper = new NamespacePrefixOverrideXmlWriter(
-                writer,
-                OpenXmlNamespacePrefix.Create(_ => "p"),
-                new OpenXmlNamespaceResolver()))
+            using (var wrapper = new NamespacePrefixOverrideXmlWriter(writer, prefixOverride))
             {
                 wrapper.WriteStartElement(string.Empty, "plain", string.Empty);
                 wrapper.WriteEndElement();
             }
 
             Assert.Equal("<plain />", builder.ToString());
-            Assert.NotNull(element);
         }
 
         [Fact]
@@ -482,17 +483,117 @@ namespace DocumentFormat.OpenXml.Framework.Tests
         }
 
         [Fact]
-        public void SetNamespacePrefixOverrideRejectsAReadOnlyCollection()
+        public void APrefixTheRootDeclaresForAnotherNamespaceIsRejected()
         {
+            // The built-in table is not the only source of taken prefixes: a loaded document can
+            // declare its own. Writing the override's binding and the document's own declaration
+            // on one start tag is a redefinition the writer refuses, so it is reported up front
+            // with the same actionable message as a reserved prefix.
+            var worksheet = new Worksheet(new SheetData());
+            worksheet.AddNamespaceDeclaration("ss", "urn:vendor");
+
+            var exception = Assert.Throws<InvalidOperationException>(() => SaveWorksheet(
+                worksheet,
+                features => features.SetNamespacePrefixOverride(ns => ns == SpreadsheetNamespace ? "ss" : null)));
+
+            Assert.Contains("'ss'", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("urn:vendor", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void APrefixADescendantDeclaresForAnotherNamespaceIsRejected()
+        {
+            var sheetData = new SheetData();
+            sheetData.AddNamespaceDeclaration("ss", "urn:vendor");
+
+            var exception = Assert.Throws<InvalidOperationException>(() => SaveWorksheet(
+                new Worksheet(sheetData),
+                features => features.SetNamespacePrefixOverride(ns => ns == SpreadsheetNamespace ? "ss" : null)));
+
+            Assert.Contains("'ss'", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("urn:vendor", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void AFeatureThatChangesItsAnswerIsStillChecked()
+        {
+            // Nothing in the contract requires a feature to answer the same prefix for a namespace
+            // every time, so the reserved-prefix check must not be skipped because an earlier answer
+            // for the namespace passed.
             using var stream = new MemoryStream();
             using var document = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook);
+
+            var calls = 0;
+            document.Features.SetNamespacePrefixOverride(
+                ns => ns == SpreadsheetNamespace ? (calls++ == 0 ? "sheet" : "r") : null);
 
             var workbookPart = document.AddWorkbookPart();
             workbookPart.Workbook = new Workbook();
 
-            Assert.Throws<InvalidOperationException>(() =>
-                workbookPart.Workbook.Features.SetNamespacePrefixOverride(
-                    OpenXmlNamespacePrefix.DefaultFor(SpreadsheetNamespace)));
+            var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+            worksheetPart.Worksheet = new Worksheet(new SheetData());
+
+            var exception = Assert.Throws<InvalidOperationException>(() => worksheetPart.Worksheet.Save());
+
+            Assert.Contains("'r'", exception.Message, StringComparison.Ordinal);
+
+            // Cleared so that disposing the document does not fail the same way.
+            document.Features.Set<IOpenXmlNamespacePrefixFeature>(null);
+        }
+
+        [Fact]
+        public void AnExtendedAttributeWithoutAPrefixUsesTheBuiltInPrefix()
+        {
+            // With the namespace bound as the default namespace the writer has no usable prefix for
+            // a qualified attribute and would invent one. Falling back to the built-in prefix keeps
+            // the attribute on x:, as it is without the override and as parsed attributes already are.
+            var sheetData = new SheetData();
+            sheetData.SetAttribute(new OpenXmlAttribute(string.Empty, "custom2", SpreadsheetNamespace, "v2"));
+
+            var worksheet = new Worksheet(sheetData);
+            worksheet.SetAttribute(new OpenXmlAttribute(string.Empty, "custom", SpreadsheetNamespace, "v"));
+
+            var xml = SaveWorksheet(
+                worksheet,
+                features => features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.DefaultFor(SpreadsheetNamespace)));
+
+            Assert.Contains("x:custom=\"v\"", xml, StringComparison.Ordinal);
+            Assert.Contains("x:custom2=\"v2\"", xml, StringComparison.Ordinal);
+            Assert.DoesNotContain("xmlns:p", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ARejectedPrefixIsReportedBeforeThePartIsWritten()
+        {
+            // Saving to a part truncates it before writing. A prefix the feature cannot honor must be
+            // rejected before that point, so the part keeps its previous content and no save events fire.
+            using var stream = new MemoryStream();
+            using var document = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook);
+
+            Populate(document);
+
+            var worksheetPart = document.WorkbookPart!.WorksheetParts.Single();
+            var worksheet = worksheetPart.Worksheet!;
+            worksheet.Save();
+
+            document.AddPartRootEventsFeature();
+
+            var saving = false;
+            document.Features.Get<IPartRootEventsFeature>()!.Change += args => saving |= args.Type == EventType.Saving;
+
+            document.Features.SetNamespacePrefixOverride(ns => ns == SpreadsheetNamespace ? "r" : null);
+
+            Assert.Throws<InvalidOperationException>(() => worksheet.Save());
+
+            Assert.False(saving);
+
+            using (var reader = new StreamReader(worksheetPart.GetStream(FileMode.Open, FileAccess.Read)))
+            {
+                Assert.Contains("<x:worksheet", reader.ReadToEnd(), StringComparison.Ordinal);
+            }
+
+            // Cleared so that disposing the document does not fail the same way.
+            document.Features.Set<IOpenXmlNamespacePrefixFeature>(null);
         }
 
         private sealed class NullPrefixFeature : IOpenXmlNamespacePrefixFeature

--- a/test/DocumentFormat.OpenXml.Framework.Tests/NamespacePrefixOverrideTests.cs
+++ b/test/DocumentFormat.OpenXml.Framework.Tests/NamespacePrefixOverrideTests.cs
@@ -1,0 +1,588 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DocumentFormat.OpenXml.Features;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using DocumentFormat.OpenXml.Validation;
+using DocumentFormat.OpenXml.Wordprocessing;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using Xunit;
+
+using Bold = DocumentFormat.OpenXml.Wordprocessing.Bold;
+using Run = DocumentFormat.OpenXml.Wordprocessing.Run;
+using RunProperties = DocumentFormat.OpenXml.Wordprocessing.RunProperties;
+using Text = DocumentFormat.OpenXml.Wordprocessing.Text;
+
+namespace DocumentFormat.OpenXml.Framework.Tests
+{
+    public class NamespacePrefixOverrideTests
+    {
+        private const string SpreadsheetNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+        private const string WordprocessingNamespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+        [Fact]
+        public void WithoutOverridePrefixIsUnchanged()
+        {
+            var xml = CreateSpreadsheet(configure: null);
+
+            Assert.Contains("<x:worksheet ", xml, StringComparison.Ordinal);
+            Assert.Contains($"xmlns:x=\"{SpreadsheetNamespace}\"", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DefaultForWritesUnprefixedRoot()
+        {
+            var xml = CreateSpreadsheet(package =>
+                package.Features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.DefaultFor(SpreadsheetNamespace)));
+
+            Assert.Contains($"<worksheet xmlns=\"{SpreadsheetNamespace}\"", xml, StringComparison.Ordinal);
+            Assert.DoesNotContain("xmlns:x=", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DefaultForWritesUnprefixedDescendants()
+        {
+            var xml = CreateSpreadsheet(package =>
+                package.Features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.DefaultFor(SpreadsheetNamespace)));
+
+            Assert.Contains("<sheetData>", xml, StringComparison.Ordinal);
+            Assert.Contains("<c r=\"A1\"", xml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<x:", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OverrideCanSupplyACustomPrefix()
+        {
+            var xml = CreateSpreadsheet(package =>
+                package.Features.SetNamespacePrefixOverride(ns => ns == SpreadsheetNamespace ? "ss" : null));
+
+            Assert.Contains("<ss:worksheet ", xml, StringComparison.Ordinal);
+            Assert.Contains($"xmlns:ss=\"{SpreadsheetNamespace}\"", xml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<x:", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OverrideOnlyAffectsTheNamespacesItClaims()
+        {
+            var xml = CreateSpreadsheet(
+                package => package.Features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.DefaultFor(SpreadsheetNamespace)),
+                part: "workbook");
+
+            // The relationship namespace is untouched, so r:id keeps working.
+            Assert.Contains("r:id=", xml, StringComparison.Ordinal);
+            Assert.Contains("xmlns:r=", xml, StringComparison.Ordinal);
+            Assert.Contains($"<workbook xmlns=\"{SpreadsheetNamespace}\"", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReturningNullFallsBackToTheBuiltInPrefix()
+        {
+            var xml = CreateSpreadsheet(package =>
+                package.Features.SetNamespacePrefixOverride(_ => null));
+
+            Assert.Contains("<x:worksheet ", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OverrideAppliesToWordprocessingToo()
+        {
+            using var stream = new MemoryStream();
+
+            using (var document = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+            {
+                document.Features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.DefaultFor(WordprocessingNamespace));
+
+                var mainPart = document.AddMainDocumentPart();
+                mainPart.Document = new Document(new Body(new Paragraph(new Run(new Text("hello")))));
+                mainPart.Document.Save();
+            }
+
+            var xml = ReadPart(stream, "word/document.xml");
+
+            Assert.Contains($"<document xmlns=\"{WordprocessingNamespace}\"", xml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<w:", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void NamespaceQualifiedAttributesDoNotFlipDescendantsBack()
+        {
+            // A w:-qualified attribute forces the underlying writer to declare xmlns:w on its
+            // element, after which XmlWriter.LookupPrefix reports "w" for the namespace. Anything
+            // resolving prefixes from the writer's scope would silently revert the rest of the
+            // subtree to w:. WordprocessingML is full of such attributes; SpreadsheetML is not,
+            // which is why the other tests here cannot catch this.
+            using var stream = new MemoryStream();
+
+            using (var document = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+            {
+                document.Features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.DefaultFor(WordprocessingNamespace));
+
+                var mainPart = document.AddMainDocumentPart();
+                var paragraph = new Paragraph(new Run(new RunProperties(new Bold { Val = true }), new Text("hello")))
+                {
+                    RsidParagraphAddition = "00AB12CD",
+                };
+
+                mainPart.Document = new Document(new Body(paragraph));
+                mainPart.Document.Save();
+            }
+
+            var xml = ReadPart(stream, "word/document.xml");
+
+            // The attribute itself must keep a real prefix - an empty prefix on an attribute means
+            // "no namespace" - but no element may be prefixed.
+            Assert.Contains("w:rsidR=\"00AB12CD\"", xml, StringComparison.Ordinal);
+            Assert.Contains("<r>", xml, StringComparison.Ordinal);
+            Assert.Contains("<t>hello</t>", xml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<w:", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OverrideAppliesToUnknownElements()
+        {
+            // OpenXmlUnknownElement writes the prefix it was parsed with rather than resolving one,
+            // so extension content would otherwise keep the built-in prefix.
+            var worksheet = new Worksheet(new SheetData());
+            worksheet.AppendChild(new OpenXmlUnknownElement("x", "custom", SpreadsheetNamespace));
+
+            var xml = SaveWorksheet(
+                worksheet,
+                features => features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.DefaultFor(SpreadsheetNamespace)));
+
+            Assert.Contains("<custom", xml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<x:", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ExistingPrefixDeclarationIsPreservedButNoElementUsesIt()
+        {
+            // A document loaded from disk carries its own xmlns:x declaration. It is kept - binding
+            // both a prefix and the default prefix to one namespace is legal, and dropping it would
+            // strand qualified attributes and mc:Ignorable values that name the prefix - but the
+            // override still decides every element name.
+            var element = new Worksheet(new SheetData(new Row(new Cell { CellReference = "A1" })));
+            element.AddNamespaceDeclaration("x", SpreadsheetNamespace);
+
+            using var stream = new MemoryStream();
+
+            using (var document = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook))
+            {
+                document.Features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.DefaultFor(SpreadsheetNamespace));
+
+                var workbookPart = document.AddWorkbookPart();
+                workbookPart.Workbook = new Workbook();
+
+                var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+                worksheetPart.Worksheet = element;
+                worksheetPart.Worksheet.Save();
+            }
+
+            var xml = ReadPart(stream, "xl/worksheets/sheet1.xml");
+
+            Assert.Contains($"xmlns=\"{SpreadsheetNamespace}\"", xml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<x:", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UnparsedRootIsWrittenVerbatim()
+        {
+            // A root supplied as raw XML and never parsed is copied through unchanged, so the
+            // override does not reach it. Forcing a parse to close that gap would re-serialize
+            // content the SDK can copy but not always re-read, so the copy wins.
+            using var stream = new MemoryStream();
+
+            using (var document = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook))
+            {
+                document.Features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.DefaultFor(SpreadsheetNamespace));
+
+                var workbookPart = document.AddWorkbookPart();
+                workbookPart.Workbook = new Workbook();
+
+                var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+                worksheetPart.Worksheet = new Worksheet(
+                    $"<x:worksheet xmlns:x=\"{SpreadsheetNamespace}\"><x:sheetData /></x:worksheet>");
+                worksheetPart.Worksheet.Save();
+            }
+
+            var xml = ReadPart(stream, "xl/worksheets/sheet1.xml");
+
+            Assert.Contains("<x:worksheet ", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ADeclaredRootPrefixKeepsQualifiedAttributesFromRedeclaringIt()
+        {
+            // With the prefix declared once on the root, a qualified attribute resolves against it
+            // instead of forcing a fresh declaration onto every element that carries one. Dropping
+            // the root declaration - as an earlier revision did - caused measurable bloat.
+            using var stream = new MemoryStream();
+
+            using (var document = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+            {
+                document.Features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.DefaultFor(WordprocessingNamespace));
+
+                var mainPart = document.AddMainDocumentPart();
+                var body = new Body();
+
+                for (var i = 0; i < 5; i++)
+                {
+                    body.AppendChild(new Paragraph(new Run(new Text("p" + i)))
+                    {
+                        RsidParagraphAddition = "00AB12CD",
+                    });
+                }
+
+                var root = new Document(body);
+                root.AddNamespaceDeclaration("w", WordprocessingNamespace);
+
+                mainPart.Document = root;
+                mainPart.Document.Save();
+            }
+
+            var xml = ReadPart(stream, "word/document.xml");
+            var declarations = xml.Split(new[] { "xmlns:w=" }, StringSplitOptions.None).Length - 1;
+
+            Assert.Equal(1, declarations);
+            Assert.DoesNotContain("<w:", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void GeneratedDocumentRedeclaresThePrefixPerQualifiedAttribute()
+        {
+            // Documented characteristic rather than a defect: with no declaration on the root, each
+            // element carrying a qualified attribute gets its own. Elements stay unprefixed either
+            // way; see ADeclaredRootPrefixKeepsQualifiedAttributesFromRedeclaringIt for the remedy.
+            using var stream = new MemoryStream();
+
+            using (var document = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+            {
+                document.Features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.DefaultFor(WordprocessingNamespace));
+
+                var mainPart = document.AddMainDocumentPart();
+                var body = new Body();
+
+                for (var i = 0; i < 3; i++)
+                {
+                    body.AppendChild(new Paragraph(new Run(new Text("p" + i)))
+                    {
+                        RsidParagraphAddition = "00AB12CD",
+                    });
+                }
+
+                mainPart.Document = new Document(body);
+                mainPart.Document.Save();
+            }
+
+            var xml = ReadPart(stream, "word/document.xml");
+
+            Assert.Equal(3, xml.Split(new[] { "xmlns:w=" }, StringSplitOptions.None).Length - 1);
+            Assert.DoesNotContain("<w:", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReservedPrefixIsRejectedRatherThanLeftToTheWriter()
+        {
+            // Claiming "r" for SpreadsheetML has no good outcome: where the relationships namespace
+            // is declared on the same element the writer refuses it outright, and where it is
+            // declared further out the writer silently rebinds it to a generated prefix, shipping
+            // r:id as p3:id with no error. Both become one actionable exception instead.
+            var exception = Assert.Throws<InvalidOperationException>(() => CreateSpreadsheet(
+                package => package.Features.SetNamespacePrefixOverride(ns => ns == SpreadsheetNamespace ? "r" : null)));
+
+            Assert.Contains("'r'", exception.Message, StringComparison.Ordinal);
+            Assert.Contains(SpreadsheetNamespace, exception.Message, StringComparison.Ordinal);
+            Assert.Contains("relationships", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void APrefixOutsideTheBuiltInTableIsAccepted()
+        {
+            var xml = CreateSpreadsheet(package =>
+                package.Features.SetNamespacePrefixOverride(ns => ns == SpreadsheetNamespace ? "sheet" : null));
+
+            Assert.Contains("<sheet:worksheet ", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ElementsInTheEmptyNamespaceAreLeftAlone()
+        {
+            // A resolver that answers for the empty namespace must not produce a prefixed element
+            // there - a prefix cannot be bound to the empty namespace.
+            var builder = new StringBuilder();
+            var element = new Worksheet(new SheetData());
+
+            using (var writer = XmlWriter.Create(builder, new XmlWriterSettings { OmitXmlDeclaration = true }))
+            using (var wrapper = new NamespacePrefixOverrideXmlWriter(
+                writer,
+                OpenXmlNamespacePrefix.Create(_ => "p"),
+                new OpenXmlNamespaceResolver()))
+            {
+                wrapper.WriteStartElement(string.Empty, "plain", string.Empty);
+                wrapper.WriteEndElement();
+            }
+
+            Assert.Equal("<plain />", builder.ToString());
+            Assert.NotNull(element);
+        }
+
+        [Fact]
+        public void DefaultForRejectsANullEntry()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => OpenXmlNamespacePrefix.DefaultFor(SpreadsheetNamespace, null!));
+
+            Assert.Equal("namespaceUris", exception.ParamName);
+        }
+
+        [Fact]
+        public void ResolverOverloadReportsANullCollection()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => ((IFeatureCollection)null!).SetNamespacePrefixOverride(_ => null));
+
+            Assert.Equal("features", exception.ParamName);
+        }
+
+        [Fact]
+        public void OutputRoundTripsBackThroughTheSdk()
+        {
+            using var stream = new MemoryStream();
+
+            using (var document = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook))
+            {
+                document.Features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.DefaultFor(SpreadsheetNamespace));
+                Populate(document);
+            }
+
+            stream.Position = 0;
+
+            using var reopened = SpreadsheetDocument.Open(stream, false);
+            var worksheetPart = reopened.WorkbookPart!.WorksheetParts.Single();
+            var cell = worksheetPart.Worksheet!.Descendants<Cell>().Single();
+
+            Assert.Equal("A1", cell.CellReference);
+            Assert.Equal("hello", cell.CellValue!.InnerText);
+
+            var errors = new OpenXmlValidator(FileFormatVersions.Office2019)
+                .Validate(reopened, TestContext.Current.CancellationToken)
+                .ToList();
+
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void PrefixPropertyIsNotAffectedByTheOverride()
+        {
+            // Prefix feeds XmlPath, which builds validation XPaths. An empty prefix there makes
+            // XmlPath emit the raw namespace URI where a prefix belongs, producing an XPath that
+            // is neither legal nor resolvable against the reported namespace manager.
+            using var stream = new MemoryStream();
+            using var document = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook);
+
+            var workbookPart = document.AddWorkbookPart();
+            workbookPart.Workbook = new Workbook();
+
+            var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+            worksheetPart.Worksheet = new Worksheet(new SheetData());
+
+            Assert.Equal("x", worksheetPart.Worksheet.Prefix);
+
+            document.Features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.DefaultFor(SpreadsheetNamespace));
+
+            Assert.Equal("x", worksheetPart.Worksheet.Prefix);
+        }
+
+        [Fact]
+        public void ValidationXPathsStayWellFormedUnderTheOverride()
+        {
+            using var stream = new MemoryStream();
+            using var document = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook);
+
+            document.Features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.DefaultFor(SpreadsheetNamespace));
+
+            var workbookPart = document.AddWorkbookPart();
+            workbookPart.Workbook = new Workbook();
+
+            var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+            worksheetPart.Worksheet = new Worksheet(new SheetData(new Row(new Cell(new SheetData())
+            {
+                CellReference = "A1",
+            })));
+
+            var error = new OpenXmlValidator(FileFormatVersions.Office2019)
+                .Validate(document, TestContext.Current.CancellationToken)
+                .First();
+
+            Assert.DoesNotContain("http://", error.Path!.XPath, StringComparison.Ordinal);
+            Assert.StartsWith("/x:", error.Path.XPath, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OverrideOutranksADeclarationOnADescendant()
+        {
+            // A descendant carrying its own xmlns:x must not keep using it, or the override is
+            // silently ignored for that subtree and the writer re-emits the declaration.
+            var sheetData = new SheetData(new Row(new Cell { CellReference = "A1" }));
+            sheetData.AddNamespaceDeclaration("x", SpreadsheetNamespace);
+
+            var xml = SaveWorksheet(
+                new Worksheet(sheetData),
+                features => features.SetNamespacePrefixOverride(OpenXmlNamespacePrefix.DefaultFor(SpreadsheetNamespace)));
+
+            Assert.Contains($"<worksheet xmlns=\"{SpreadsheetNamespace}\"", xml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<x:", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomPrefixOverrideAppliesToDescendantsToo()
+        {
+            // A declaration for a different prefix on the same namespace is left alone; what
+            // matters is that the override, not the declaration, decides every element name.
+            var worksheet = new Worksheet(new SheetData(new Row(new Cell { CellReference = "A1" })));
+            worksheet.AddNamespaceDeclaration("x", SpreadsheetNamespace);
+
+            var xml = SaveWorksheet(
+                worksheet,
+                features => features.SetNamespacePrefixOverride(ns => ns == SpreadsheetNamespace ? "ss" : null));
+
+            Assert.Contains("<ss:worksheet ", xml, StringComparison.Ordinal);
+            Assert.Contains("<ss:sheetData>", xml, StringComparison.Ordinal);
+            Assert.DoesNotContain("<x:", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CallerSuppliedWriterIsUnaffectedWhenNoFeatureIsRegistered()
+        {
+            // Writing into a writer that already binds the namespace as the default must still
+            // produce the built-in prefix, so output is genuinely unchanged without an override.
+            var builder = new StringBuilder();
+
+            using (var writer = XmlWriter.Create(builder, new XmlWriterSettings { OmitXmlDeclaration = true }))
+            {
+                writer.WriteStartElement(string.Empty, "wrapper", WordprocessingNamespace);
+                new Paragraph(new Run(new Text("hi"))).WriteTo(writer);
+                writer.WriteEndElement();
+            }
+
+            Assert.Contains("<w:p ", builder.ToString(), StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void FeatureReportingSuccessWithANullPrefixIsTreatedAsTheDefaultNamespace()
+        {
+            var xml = CreateSpreadsheet(package =>
+                package.Features.SetNamespacePrefixOverride(new NullPrefixFeature()));
+
+            Assert.Contains($"<worksheet xmlns=\"{SpreadsheetNamespace}\"", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SetNamespacePrefixOverrideRejectsAReadOnlyCollection()
+        {
+            using var stream = new MemoryStream();
+            using var document = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook);
+
+            var workbookPart = document.AddWorkbookPart();
+            workbookPart.Workbook = new Workbook();
+
+            Assert.Throws<InvalidOperationException>(() =>
+                workbookPart.Workbook.Features.SetNamespacePrefixOverride(
+                    OpenXmlNamespacePrefix.DefaultFor(SpreadsheetNamespace)));
+        }
+
+        private sealed class NullPrefixFeature : IOpenXmlNamespacePrefixFeature
+        {
+            public bool TryGetPrefix(string namespaceUri, out string prefix)
+            {
+                prefix = null!;
+                return namespaceUri == SpreadsheetNamespace;
+            }
+        }
+
+        private static string SaveWorksheet(Worksheet worksheet, Action<IFeatureCollection> configure)
+        {
+            using var stream = new MemoryStream();
+
+            using (var document = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook))
+            {
+                configure(document.Features);
+
+                var workbookPart = document.AddWorkbookPart();
+                workbookPart.Workbook = new Workbook();
+
+                var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+                worksheetPart.Worksheet = worksheet;
+                worksheetPart.Worksheet.Save();
+            }
+
+            return ReadPart(stream, "xl/worksheets/sheet1.xml");
+        }
+
+        [Fact]
+        public void DefaultForRejectsNull()
+            => Assert.Throws<ArgumentNullException>(() => OpenXmlNamespacePrefix.DefaultFor(null!));
+
+        [Fact]
+        public void CreateRejectsNull()
+            => Assert.Throws<ArgumentNullException>(() => OpenXmlNamespacePrefix.Create(null!));
+
+        [Fact]
+        public void SetNamespacePrefixOverrideRejectsNullFeature()
+        {
+            var features = new FeatureCollection();
+
+            Assert.Throws<ArgumentNullException>(() => features.SetNamespacePrefixOverride((IOpenXmlNamespacePrefixFeature)null!));
+        }
+
+        private static string CreateSpreadsheet(Action<SpreadsheetDocument>? configure, string part = "worksheet")
+        {
+            using var stream = new MemoryStream();
+
+            using (var document = SpreadsheetDocument.Create(stream, SpreadsheetDocumentType.Workbook))
+            {
+                configure?.Invoke(document);
+                Populate(document);
+            }
+
+            return ReadPart(stream, part == "workbook" ? "xl/workbook.xml" : "xl/worksheets/sheet1.xml");
+        }
+
+        private static void Populate(SpreadsheetDocument document)
+        {
+            var workbookPart = document.AddWorkbookPart();
+            workbookPart.Workbook = new Workbook();
+
+            var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+            worksheetPart.Worksheet = new Worksheet(new SheetData(new Row(new Cell
+            {
+                CellReference = "A1",
+                DataType = CellValues.String,
+                CellValue = new CellValue("hello"),
+            })));
+
+            var sheets = workbookPart.Workbook.AppendChild(new Sheets());
+            sheets.Append(new Sheet
+            {
+                Id = workbookPart.GetIdOfPart(worksheetPart),
+                SheetId = 1,
+                Name = "Sheet1",
+            });
+        }
+
+        private static string ReadPart(MemoryStream stream, string uri)
+        {
+            stream.Position = 0;
+
+            using var package = System.IO.Packaging.Package.Open(stream, FileMode.Open, FileAccess.Read);
+            using var partStream = package.GetPart(new Uri("/" + uri, UriKind.Relative)).GetStream();
+            using var reader = new StreamReader(partStream);
+
+            return reader.ReadToEnd();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Elements are serialized with a built-in prefix for their namespace, so a worksheet is written as `<x:worksheet xmlns:x="...">` where Office writes `<worksheet xmlns="...">`. Both are valid, but consumers that parse without a namespace manager are sensitive to the difference, and there was no way to choose.

This adds an opt-in feature registered on the package:

```csharp
document.Features.SetNamespacePrefixOverride(
    OpenXmlNamespacePrefix.DefaultFor("http://schemas.openxmlformats.org/spreadsheetml/2006/main"));
```

`OpenXmlNamespacePrefix.Create(Func<string, string?>)` supports arbitrary prefixes per namespace. Output and `OpenXmlElement.Prefix` are unchanged when no feature is registered.

Resolves https://github.com/dotnet/Open-XML-SDK/issues/90

## Problem

Elements are serialized with a built-in prefix for their namespace, so the SDK writes

```xml
<x:worksheet xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
```

where Office writes

```xml
<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
```

Both are valid and Excel reads either. The difference matters to consumers that parse the XML without a namespace manager — XPath, regex, strict diffing — and there is currently no way to choose. Opening an Office-authored file and saving it also converts it to the prefixed form, because default-namespace declarations are discarded at parse time (`OpenXmlElement.cs:1583`).

## Design

- The override is applied by an `XmlWriter` decorator wrapped around the part root rather than while resolving each element's prefix. A namespace-qualified attribute such as `w:rsidR` forces the underlying writer to declare the built-in prefix on its element, after which `XmlWriter.LookupPrefix` reports that prefix, so any decision taken from the writer's scope would silently revert the rest of the subtree. Forcing the prefix as each element is written keeps the whole tree consistent and covers unknown and extension elements.
- Every namespace the part uses is validated before the part stream is opened, so a rejected prefix leaves the previous part content intact. A prefix already bound to another namespace, by the built-in table or by a declaration in the document, is rejected with an `InvalidOperationException` naming both namespaces. Taking one would otherwise either be refused by the writer as a redefinition or silently rebind the other namespace to a generated prefix (`r:id` shipping as `p3:id`).
- Existing namespace declarations are preserved, so round-tripped documents keep what they declared and `mc:Ignorable` values are not stranded.
- Descendants written under the override reuse the namespace resolver the root resolved, instead of walking to the part root through the feature chain per element. The override path performs one tree walk per save, the same as the un-overridden path.
- The two internal `XmlWriter` decorators share a forwarding base class.

## Scope and limits

Documented on `IOpenXmlNamespacePrefixFeature`: `OpenXmlElement.Prefix` is untouched so validation XPaths stay well formed; an unparsed part root is still copied verbatim; `OpenXmlPartWriter` and the LINQ-to-XML save path are unaffected.

## Tests

33 tests in `NamespacePrefixOverrideTests` cover SpreadsheetML and WordprocessingML output, qualified attributes, unknown elements, declared and reserved prefixes, validation ordering, round-tripping, and the unchanged default behavior.

## Performance

Saving a 50,000-row, 250,000-cell worksheet to memory, best of five runs, net10.0 Release:

| Build | No override | With override | Overhead |
|---|---|---|---|
| Before patch | 184 ms | 242 ms | +58 ms |
| After patch | 189 ms | 211 ms | +22 ms |

The remaining overhead is the decorator's per-element dispatch and the feature's prefix lookup.